### PR TITLE
11 fix contract ids not showing encoded addresses

### DIFF
--- a/src/mappings/nabla.ts
+++ b/src/mappings/nabla.ts
@@ -87,7 +87,7 @@ async function getEventAndEventType(ctx: EventHandlerContext): Promise<{
     event: Event | null
     eventType: EventType | null
 }> {
-    const veryfiers = [isBackstopPoolEvent, isRouterEvent, isSwapPoolEvent]
+    const verifiers = [isBackstopPoolEvent, isRouterEvent, isSwapPoolEvent]
     const decoders = [backstopPoolAbi, routerAbi, swapPoolAbi]
     const eventTypes = [
         EventType.BackstopPoolEvent,

--- a/src/mappings/nabla.ts
+++ b/src/mappings/nabla.ts
@@ -78,8 +78,8 @@ async function isBackstopPoolEvent(ctx: EventHandlerContext) {
     }
 }
 
-async function verifyEvent(veryfier: Function, ctx: EventHandlerContext) {
-    return veryfier(ctx)
+async function verifyEvent(verifier: Function, ctx: EventHandlerContext) {
+    return verifier(ctx)
 }
 
 // Iterates over all decoders and returns the first successfully decoded event

--- a/src/mappings/nabla.ts
+++ b/src/mappings/nabla.ts
@@ -95,8 +95,9 @@ async function getEventAndEventType(ctx: EventHandlerContext): Promise<{
         EventType.SwapPoolEvent,
     ]
 
-    for (let i = 0; i < veryfiers.length; i++) {
-        if (await verifyEvent(veryfiers[i], ctx)) {
+    // Iterate over all verifiers and try to decode the event to the given type
+    for (let i = 0; i < verifiers.length; i++) {
+        if (await verifyEvent(verifiers[i], ctx)) {
             const { result: event, error: err } = decodeEvent(
                 ctx.event.args.data,
                 decoders[i]

--- a/src/mappings/nabla.ts
+++ b/src/mappings/nabla.ts
@@ -42,17 +42,53 @@ function decodeEvent(
     }
 }
 
+function isSwapPoolEvent(ctx: EventHandlerContext) {
+    const contract = new swapPoolAbi.Contract(ctx, ctx.event.args.contract)
+
+    try {
+        contract.router()
+        contract.backstop()
+        contract.accumulatedSlippage()
+        contract.poolCap()
+        return true
+    } catch {
+        return false
+    }
+}
+
+function isRouterEvent(ctx: EventHandlerContext) {
+    const contract = new routerAbi.Contract(ctx, ctx.event.args.contract)
+
+    try {
+        contract.poolByAsset(new Uint8Array(Buffer.from('0x00', 'hex')))
+        return true
+    } catch {
+        return false
+    }
+}
+
+function isBacstopPoolEvent(ctx: EventHandlerContext) {
+    const contract = new backstopPoolAbi.Contract(ctx, ctx.event.args.contract)
+
+    try {
+        contract.getBackedPool(0n)
+        return true
+    } catch {
+        return false
+    }
+}
+
 // Iterates over all decoders and returns the first successfully decoded event
 function getEventAndEventType(ctx: EventHandlerContext): {
     event: Event | null
     eventType: EventType | null
 } {
-    const decoders = [erc20Abi, backstopPoolAbi, swapPoolAbi, routerAbi]
+    const decoders = [erc20Abi, swapPoolAbi, routerAbi, backstopPoolAbi]
     const eventTypes = [
         null,
-        EventType.BackstopPoolEvent,
         EventType.SwapPoolEvent,
         EventType.RouterEvent,
+        EventType.BackstopPoolEvent,
     ]
 
     for (let i = 0; i < decoders.length; i++) {


### PR DESCRIPTION
The addresses in the router, swap pool, and backstop pool IDs were saved as hex addresses. However, for the Nabla project, we require SS58 addresses.

This pull request modifies how we store addresses in the entities. Additionally, we identified an error when decoding events, which has been resolved by making calls to the smart contracts to determine the origin of the event.

Closes [this](https://github.com/pendulum-chain/pendulum-squids/issues/11) issue.