### PR TITLE
17 farming apr not showing up on production zenlink UI

### DIFF
--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 4
+version: 5
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -47,6 +47,8 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
             event = _event.asV3
         } else if (_event.isV8) {
             event = _event.asV8
+        } else if (_event.isV10) {
+            event = _event.asV10
         }
     }
 
@@ -97,6 +99,7 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
     pair.totalSupply = (
         await getPairStatusFromAssets(ctx, [asset0, asset1], false)
     )[1].toString()
+    console.log('set pair total supply', pair.totalSupply)
     const { burns, mints } = transaction
     let burn: Burn
     if (burns.length > 0) {
@@ -176,6 +179,8 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
             event = _event.asV3
         } else if (_event.isV8) {
             event = _event.asV8
+        } else if (_event.isV10) {
+            event = _event.asV10
         }
     }
 
@@ -226,6 +231,7 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
     pair.totalSupply = (
         await getPairStatusFromAssets(ctx, [asset0, asset1], false)
     )[1].toString()
+    console.log('also set pair.totalSupply', pair.totalSupply)
     const { burns, mints } = transaction
     let burn: Burn
     if (burns.length > 0) {
@@ -302,6 +308,8 @@ export async function handleTokenTransfer(ctx: EventHandlerContext) {
             event = _event.asV3
         } else if (_event.isV8) {
             event = _event.asV8
+        } else if (_event.isV10) {
+            event = _event.asV10
         }
     }
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -384,6 +384,8 @@ export async function getTotalIssuance(
                 result = await tokenIssuanceStorage.asV3.get(assetId as any)
             } else if (tokenIssuanceStorage.isV8) {
                 result = await tokenIssuanceStorage.asV8.get(assetId as any)
+            } else if (tokenIssuanceStorage.isV10) {
+                result = await tokenIssuanceStorage.asV10.get(assetId as any)
             }
         }
     }
@@ -426,6 +428,11 @@ export async function getTokenBurned(
                 )
             } else if (tokenAccountsStorage.isV8) {
                 result = await tokenAccountsStorage.asV8.get(
+                    account,
+                    assetId as any
+                )
+            } else if (tokenAccountsStorage.isV10) {
+                result = await tokenAccountsStorage.asV10.get(
                     account,
                     assetId as any
                 )


### PR DESCRIPTION
We were missing some other checks for the `v10` in the Amplitude handlers. This lead to the `totalSupply` of the pair not being queried properly, which in turn lead to wrong (ie. `0`) APR values.

Closes #17.