### PR TITLE
14 create squid indexer for pendulum network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pendulum Squids
 
-This repository contains the code for the subsquid indexers that we deploy for our three networks Pendulum, Amplitude, and Foucoco. 
+This repository contains the code for the subsquid indexers that we deploy for our three networks Pendulum, Amplitude, and Foucoco.
 
 ## Prerequisites
 
@@ -26,6 +26,8 @@ sqd up
 
 # 4. Start the processor
 # For amplitude you would use
+sqd process:pendulum
+# For amplitude you would use
 sqd process:amplitude
 # For foucoco you would use
 sqd process:foucoco
@@ -39,7 +41,7 @@ sqd process:foucoco
 sqd serve
 ```
 
-## Context 
+## Context
 
 ### Organizations
 
@@ -108,6 +110,8 @@ in [this](https://docs.subsquid.io/deploy-squid/quickstart/) document.
 Deploying the squid to the `pendulum` organization is done by running the following command:
 
 ```shell
+# Deploying the pendulum squid
+sqd deploy --org pendulum . -m squid-pendulum.yaml
 # Deploying the amplitude squid
 sqd deploy --org pendulum . -m squid-amplitude.yaml
 # Deploying the foucoco squid
@@ -120,6 +124,7 @@ To deploy the squid to the production environment you should run the following c
 
 ```shell
 # Replace {version} with the version you define in the `squid.yaml` file
+sqd prod pendulum-squid@{version}
 sqd prod amplitude-squid@{version}
 sqd prod foucoco-squid@{version}
 ```
@@ -146,6 +151,12 @@ sqd typegen
 ```
 
 In our case, we have two typegen files: `typegen-amplitude.json` and `typegen-foucoco.json`. The previous command should be replaced by
+
+```shell
+sqd typegen:pendulum
+```
+
+Or
 
 ```shell
 sqd typegen:amplitude

--- a/commands.json
+++ b/commands.json
@@ -48,6 +48,10 @@
             "description": "Generate data access classes for an substrate metadata",
             "cmd": ["squid-substrate-typegen", "./typegen-foucoco.json"]
         },
+        "typegen:pendulum": {
+            "description": "Generate data access classes for an substrate metadata",
+            "cmd": ["squid-substrate-typegen", "./typegen-pendulum.json"]
+        },
         "process:foucoco": {
             "description": "Load .env and start the squid processor for Foucoco",
             "deps": ["build", "migration:apply"],
@@ -62,6 +66,14 @@
             "cmd": ["node", "--require=dotenv/config", "lib/processor.js"],
             "env": {
                 "NETWORK": "amplitude"
+            }
+        },
+        "process:pendulum": {
+            "description": "Load .env and start the squid processor for Pendulum",
+            "deps": ["build", "migration:apply"],
+            "cmd": ["node", "--require=dotenv/config", "lib/processor.js"],
+            "env": {
+                "NETWORK": "pendulum"
             }
         },
         "process:prod": {

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,0 +1,26 @@
+manifestVersion: subsquid.io/v0.1
+name: pendulum-squid
+version: 1
+description: 'Pendulum Squid'
+build:
+deploy:
+    addons:
+        postgres:
+    processor:
+        env:
+            NETWORK: 'pendulum'
+        cmd:
+            - node
+            - lib/processor
+    api:
+        cmd:
+            - npx
+            - squid-graphql-server
+            - '--dumb-cache'
+            - in-memory
+            - '--dumb-cache-ttl'
+            - '1000'
+            - '--dumb-cache-size'
+            - '100'
+            - '--dumb-cache-max-age'
+            - '1000'

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,17 @@
 import { ProcessorConfig } from './types'
 
-export type Network = 'foucoco' | 'amplitude'
+export type Network = 'foucoco' | 'amplitude' | 'pendulum'
 export const network: Network =
-    <'foucoco' | 'amplitude'>process.env.NETWORK || 'amplitude'
+    <'foucoco' | 'amplitude' | 'pendulum'>process.env.NETWORK || 'amplitude'
+
+const pendulumConfig: ProcessorConfig = {
+    chainName: 'pendulum',
+    prefix: 'pendulum',
+    dataSource: {
+        archive: 'https://pendulum.archive.subsquid.io/graphql',
+        chain: 'wss://rpc-pendulum.pendulumchain.tech',
+    },
+}
 
 const amplitudeConfig: ProcessorConfig = {
     chainName: 'amplitude',
@@ -23,6 +32,10 @@ const foucocoConfig: ProcessorConfig = {
 }
 
 export const config: ProcessorConfig =
-    network === 'foucoco' ? foucocoConfig : amplitudeConfig
+    network === 'foucoco'
+        ? foucocoConfig
+        : network === 'amplitude'
+        ? amplitudeConfig
+        : pendulumConfig
 
 console.log('Using ProcessorConfig: ', config)

--- a/src/mappings/prices.ts
+++ b/src/mappings/prices.ts
@@ -1,16 +1,22 @@
 import { EventHandlerContext } from '../types'
-import { foucocoEvents, amplitudeEvents } from '../types/events'
+import { foucocoEvents, amplitudeEvents, pendulumEvents } from '../types/events'
 import { network } from '../config'
 import { getOrCreateOraclePrice } from '../entities/oraclePrice'
 
 export async function handleUpdatedPrices(ctx: EventHandlerContext) {
     let event
-    if (network !== 'foucoco') {
+    if (network === 'foucoco') {
         const _event = new foucocoEvents.DiaOracleModuleUpdatedPricesEvent(
             ctx,
             ctx.event
         )
         event = _event.asV1
+    } else if (network === 'pendulum') {
+        const _event = new pendulumEvents.DiaOracleModuleUpdatedPricesEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV3
     } else {
         const _event = new amplitudeEvents.DiaOracleModuleUpdatedPricesEvent(
             ctx,

--- a/src/mappings/protocol.ts
+++ b/src/mappings/protocol.ts
@@ -172,11 +172,11 @@ export async function handleLiquidityAdded(ctx: EventHandlerContext) {
         )
         event = _event.asV1
     } else if (network == 'pendulum') {
-        const _event = new foucocoEvents.ZenlinkProtocolLiquidityAddedEvent(
+        const _event = new pendulumEvents.ZenlinkProtocolLiquidityAddedEvent(
             ctx,
             ctx.event
         )
-        event = _event.asV1
+        event = _event.asV3
     } else {
         const _event = new amplitudeEvents.ZenlinkProtocolLiquidityAddedEvent(
             ctx,
@@ -254,11 +254,11 @@ export async function handleLiquidityRemoved(ctx: EventHandlerContext) {
         )
         event = _event.asV1
     } else if (network == 'pendulum') {
-        const _event = new foucocoEvents.ZenlinkProtocolLiquidityRemovedEvent(
+        const _event = new pendulumEvents.ZenlinkProtocolLiquidityRemovedEvent(
             ctx,
             ctx.event
         )
-        event = _event.asV1
+        event = _event.asV3
     } else {
         const _event = new amplitudeEvents.ZenlinkProtocolLiquidityRemovedEvent(
             ctx,
@@ -352,11 +352,11 @@ export async function handleAssetSwap(ctx: EventHandlerContext) {
         )
         event = _event.asV1
     } else if (network == 'pendulum') {
-        const _event = new foucocoEvents.ZenlinkProtocolAssetSwapEvent(
+        const _event = new pendulumEvents.ZenlinkProtocolAssetSwapEvent(
             ctx,
             ctx.event
         )
-        event = _event.asV1
+        event = _event.asV3
     } else {
         const _event = new amplitudeEvents.ZenlinkProtocolAssetSwapEvent(
             ctx,

--- a/src/mappings/protocol.ts
+++ b/src/mappings/protocol.ts
@@ -3,7 +3,7 @@ import { getFactory, getTransaction } from '../entities/utils'
 import { Big as BigDecimal } from 'big.js'
 import { Bundle, Burn, Mint, Pair, Swap, Transaction, User } from '../model'
 import { EventHandlerContext } from '../types'
-import { amplitudeEvents, foucocoEvents } from '../types/events'
+import { amplitudeEvents, foucocoEvents, pendulumEvents } from '../types/events'
 import { convertTokenToDecimal } from '../utils/helpers'
 import { sortAssets } from '../utils/sort'
 import {
@@ -171,6 +171,12 @@ export async function handleLiquidityAdded(ctx: EventHandlerContext) {
             ctx.event
         )
         event = _event.asV1
+    } else if (network == 'pendulum') {
+        const _event = new foucocoEvents.ZenlinkProtocolLiquidityAddedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.ZenlinkProtocolLiquidityAddedEvent(
             ctx,
@@ -242,6 +248,12 @@ export async function handleLiquidityRemoved(ctx: EventHandlerContext) {
 
     let event
     if (network === 'foucoco') {
+        const _event = new foucocoEvents.ZenlinkProtocolLiquidityRemovedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
+    } else if (network == 'pendulum') {
         const _event = new foucocoEvents.ZenlinkProtocolLiquidityRemovedEvent(
             ctx,
             ctx.event
@@ -334,6 +346,12 @@ export async function handleAssetSwap(ctx: EventHandlerContext) {
 
     let event
     if (network === 'foucoco') {
+        const _event = new foucocoEvents.ZenlinkProtocolAssetSwapEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
+    } else if (network == 'pendulum') {
         const _event = new foucocoEvents.ZenlinkProtocolAssetSwapEvent(
             ctx,
             ctx.event

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -17,7 +17,7 @@ import {
     Transaction,
     User,
 } from '../model'
-import { amplitudeEvents, foucocoEvents } from '../types/events'
+import { amplitudeEvents, foucocoEvents, pendulumEvents } from '../types/events'
 import { network } from '../config'
 import {
     getPairAssetIdFromAssets,
@@ -41,9 +41,13 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
-    } else if (network == 'pendulum') {
-        const _event = new foucocoEvents.TokensDepositedEvent(ctx, ctx.event)
-        event = _event.asV1
+    } else if (network === 'pendulum') {
+        const _event = new pendulumEvents.TokensDepositedEvent(ctx, ctx.event)
+        if (_event.isV1) {
+            event = _event.asV1
+        } else {
+            event = _event.asV3
+        }
     } else {
         const _event = new amplitudeEvents.TokensDepositedEvent(ctx, ctx.event)
         if (_event.isV3) {
@@ -176,9 +180,13 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
-    } else if (network == 'pendulum') {
-        const _event = new foucocoEvents.TokensWithdrawnEvent(ctx, ctx.event)
-        event = _event.asV1
+    } else if (network === 'pendulum') {
+        const _event = new pendulumEvents.TokensWithdrawnEvent(ctx, ctx.event)
+        if (_event.isV1) {
+            event = _event.asV1
+        } else {
+            event = _event.asV3
+        }
     } else {
         const _event = new amplitudeEvents.TokensWithdrawnEvent(ctx, ctx.event)
         if (_event.isV3) {
@@ -308,9 +316,13 @@ export async function handleTokenTransfer(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
-    } else if (network == 'pendulum') {
-        const _event = new foucocoEvents.TokensTransferEvent(ctx, ctx.event)
-        event = _event.asV1
+    } else if (network === 'pendulum') {
+        const _event = new pendulumEvents.TokensDepositedEvent(ctx, ctx.event)
+        if (_event.isV1) {
+            event = _event.asV1
+        } else {
+            event = _event.asV3
+        }
     } else {
         const _event = new amplitudeEvents.TokensTransferEvent(ctx, ctx.event)
         if (_event.isV3) {

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -317,7 +317,7 @@ export async function handleTokenTransfer(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
-        const _event = new pendulumEvents.TokensDepositedEvent(ctx, ctx.event)
+        const _event = new pendulumEvents.TokensTransferEvent(ctx, ctx.event)
         if (_event.isV1) {
             event = _event.asV1
         } else {

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -41,6 +41,9 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network == 'pendulum') {
+        const _event = new foucocoEvents.TokensDepositedEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.TokensDepositedEvent(ctx, ctx.event)
         if (_event.isV3) {
@@ -173,6 +176,9 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network == 'pendulum') {
+        const _event = new foucocoEvents.TokensWithdrawnEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.TokensWithdrawnEvent(ctx, ctx.event)
         if (_event.isV3) {
@@ -302,6 +308,9 @@ export async function handleTokenTransfer(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network == 'pendulum') {
+        const _event = new foucocoEvents.TokensTransferEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.TokensTransferEvent(ctx, ctx.event)
         if (_event.isV3) {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,9 +1,15 @@
 import * as amplitudeEvents from './amplitude/events'
 import * as foucocoEvents from './foucoco/events'
+import * as pendulumEvents from './pendulum/events'
 
 import { network } from '../config'
 
-const events = network === 'foucoco' ? foucocoEvents : amplitudeEvents
+const events =
+    network === 'foucoco'
+        ? foucocoEvents
+        : network === 'amplitude'
+        ? amplitudeEvents
+        : pendulumEvents
 
-export { amplitudeEvents, foucocoEvents }
+export { amplitudeEvents, foucocoEvents, pendulumEvents }
 export default events

--- a/src/types/pendulum/events.ts
+++ b/src/types/pendulum/events.ts
@@ -1,0 +1,403 @@
+import assert from 'assert'
+import {
+    Chain,
+    ChainContext,
+    EventContext,
+    Event,
+    Result,
+    Option,
+} from './support'
+import * as v1 from './v1'
+import * as v3 from './v3'
+
+export class BalancesTransferEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Balances.Transfer')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Transfer succeeded.
+     */
+    get isV1(): boolean {
+        return (
+            this._chain.getEventHash('Balances.Transfer') ===
+            '0ffdf35c495114c2d42a8bf6c241483fd5334ca0198662e14480ad040f1e3a66'
+        )
+    }
+
+    /**
+     * Transfer succeeded.
+     */
+    get asV1(): { from: Uint8Array; to: Uint8Array; amount: bigint } {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class DiaOracleModuleUpdatedPricesEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'DiaOracleModule.UpdatedPrices')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Event is triggered when prices are updated
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('DiaOracleModule.UpdatedPrices') ===
+            'a95ec71ae20ecf7d0621b22ad3f636dc4dea11a58a924e27d208ba412c7fe74d'
+        )
+    }
+
+    /**
+     * Event is triggered when prices are updated
+     */
+    get asV3(): [[Uint8Array, Uint8Array], v3.CoinInfo][] {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class TokensBalanceSetEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Tokens.BalanceSet')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * A balance was set by root.
+     */
+    get isV1(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.BalanceSet') ===
+            '219ad45ff6115e031aeed1bc3cec4777aebb69e21e0502d08df00e5cbc1328e1'
+        )
+    }
+
+    /**
+     * A balance was set by root.
+     */
+    get asV1(): {
+        currencyId: v1.CurrencyId
+        who: Uint8Array
+        free: bigint
+        reserved: bigint
+    } {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * A balance was set by root.
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.BalanceSet') ===
+            '352dd1eb5aa782b5cb915ad1a616eea87e66963ca53146b83e647b650af30751'
+        )
+    }
+
+    /**
+     * A balance was set by root.
+     */
+    get asV3(): {
+        currencyId: v3.CurrencyId
+        who: Uint8Array
+        free: bigint
+        reserved: bigint
+    } {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class TokensDepositedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Tokens.Deposited')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Deposited some balance into an account
+     */
+    get isV1(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.Deposited') ===
+            'a8442ff01fe9baaf51b3bb3ae62365d8100656ccc162be57ce70e5024778755e'
+        )
+    }
+
+    /**
+     * Deposited some balance into an account
+     */
+    get asV1(): { currencyId: v1.CurrencyId; who: Uint8Array; amount: bigint } {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * Deposited some balance into an account
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.Deposited') ===
+            'c07b65b17f9ab4499880c4f2d15007e67d3ad1abb4da4ae0fc46a8c3e3d626ca'
+        )
+    }
+
+    /**
+     * Deposited some balance into an account
+     */
+    get asV3(): { currencyId: v3.CurrencyId; who: Uint8Array; amount: bigint } {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class TokensTransferEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Tokens.Transfer')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Transfer succeeded.
+     */
+    get isV1(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.Transfer') ===
+            'e8955df470c71892e6c76efd5b0ffb98dc64b4199dfcf705d9315063376817be'
+        )
+    }
+
+    /**
+     * Transfer succeeded.
+     */
+    get asV1(): {
+        currencyId: v1.CurrencyId
+        from: Uint8Array
+        to: Uint8Array
+        amount: bigint
+    } {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * Transfer succeeded.
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.Transfer') ===
+            '6540edfd4c34e23f8c1b93fdaacba40ae3a9a98eae38b1dff93c38ae37186a0f'
+        )
+    }
+
+    /**
+     * Transfer succeeded.
+     */
+    get asV3(): {
+        currencyId: v3.CurrencyId
+        from: Uint8Array
+        to: Uint8Array
+        amount: bigint
+    } {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class TokensWithdrawnEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'Tokens.Withdrawn')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Some balances were withdrawn (e.g. pay for transaction fee)
+     */
+    get isV1(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.Withdrawn') ===
+            'a8442ff01fe9baaf51b3bb3ae62365d8100656ccc162be57ce70e5024778755e'
+        )
+    }
+
+    /**
+     * Some balances were withdrawn (e.g. pay for transaction fee)
+     */
+    get asV1(): { currencyId: v1.CurrencyId; who: Uint8Array; amount: bigint } {
+        assert(this.isV1)
+        return this._chain.decodeEvent(this.event)
+    }
+
+    /**
+     * Some balances were withdrawn (e.g. pay for transaction fee)
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('Tokens.Withdrawn') ===
+            'c07b65b17f9ab4499880c4f2d15007e67d3ad1abb4da4ae0fc46a8c3e3d626ca'
+        )
+    }
+
+    /**
+     * Some balances were withdrawn (e.g. pay for transaction fee)
+     */
+    get asV3(): { currencyId: v3.CurrencyId; who: Uint8Array; amount: bigint } {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class ZenlinkProtocolAssetSwapEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'ZenlinkProtocol.AssetSwap')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Transact in trading \[owner, recipient, swap_path, balances\]
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('ZenlinkProtocol.AssetSwap') ===
+            'e9cbb9bf25ce7ca78f66cb163c5de7b5b796a1f9f5cf2f1d1955496bd76f264e'
+        )
+    }
+
+    /**
+     * Transact in trading \[owner, recipient, swap_path, balances\]
+     */
+    get asV3(): [Uint8Array, Uint8Array, v3.AssetId[], bigint[]] {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class ZenlinkProtocolLiquidityAddedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'ZenlinkProtocol.LiquidityAdded')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Add liquidity. \[owner, asset_0, asset_1, add_balance_0, add_balance_1,
+     * mint_balance_lp\]
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('ZenlinkProtocol.LiquidityAdded') ===
+            '1bfafadda80f84623e855502fa86cbd5fb805fa26a6254ee45104d1d976c2219'
+        )
+    }
+
+    /**
+     * Add liquidity. \[owner, asset_0, asset_1, add_balance_0, add_balance_1,
+     * mint_balance_lp\]
+     */
+    get asV3(): [Uint8Array, v3.AssetId, v3.AssetId, bigint, bigint, bigint] {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}
+
+export class ZenlinkProtocolLiquidityRemovedEvent {
+    private readonly _chain: Chain
+    private readonly event: Event
+
+    constructor(ctx: EventContext)
+    constructor(ctx: ChainContext, event: Event)
+    constructor(ctx: EventContext, event?: Event) {
+        event = event || ctx.event
+        assert(event.name === 'ZenlinkProtocol.LiquidityRemoved')
+        this._chain = ctx._chain
+        this.event = event
+    }
+
+    /**
+     * Remove liquidity. \[owner, recipient, asset_0, asset_1, rm_balance_0, rm_balance_1,
+     * burn_balance_lp\]
+     */
+    get isV3(): boolean {
+        return (
+            this._chain.getEventHash('ZenlinkProtocol.LiquidityRemoved') ===
+            '9decbbc0fd030ae8322c18bf256e4f3ace487600f6cf3b11b8961ab923a40bf1'
+        )
+    }
+
+    /**
+     * Remove liquidity. \[owner, recipient, asset_0, asset_1, rm_balance_0, rm_balance_1,
+     * burn_balance_lp\]
+     */
+    get asV3(): [
+        Uint8Array,
+        Uint8Array,
+        v3.AssetId,
+        v3.AssetId,
+        bigint,
+        bigint,
+        bigint
+    ] {
+        assert(this.isV3)
+        return this._chain.decodeEvent(this.event)
+    }
+}

--- a/src/types/pendulum/storage.ts
+++ b/src/types/pendulum/storage.ts
@@ -1,0 +1,600 @@
+import assert from 'assert'
+import {
+    Block,
+    BlockContext,
+    Chain,
+    ChainContext,
+    Option,
+    Result,
+    StorageBase,
+} from './support'
+import * as v1 from './v1'
+import * as v3 from './v3'
+
+export class BalancesTotalIssuanceStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Balances'
+    }
+
+    protected getName() {
+        return 'TotalIssuance'
+    }
+
+    /**
+     *  The total units issued in the system.
+     */
+    get isV1(): boolean {
+        return (
+            this.getTypeHash() ===
+            'f8ebe28eb30158172c0ccf672f7747c46a244f892d08ef2ebcbaadde34a26bc0'
+        )
+    }
+
+    /**
+     *  The total units issued in the system.
+     */
+    get asV1(): BalancesTotalIssuanceStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The total units issued in the system.
+ */
+export interface BalancesTotalIssuanceStorageV1 {
+    get(): Promise<bigint>
+}
+
+export class DiaOracleModuleCoinInfosMapStorage extends StorageBase {
+    protected getPrefix() {
+        return 'DiaOracleModule'
+    }
+
+    protected getName() {
+        return 'CoinInfosMap'
+    }
+
+    /**
+     *  Map of all the coins names to their respective info and price
+     */
+    get isV3(): boolean {
+        return (
+            this.getTypeHash() ===
+            'ca6255144b7cf6607b20ac2559a85f4365b5839095dca04f10bcdbb06d6b7d8f'
+        )
+    }
+
+    /**
+     *  Map of all the coins names to their respective info and price
+     */
+    get asV3(): DiaOracleModuleCoinInfosMapStorageV3 {
+        assert(this.isV3)
+        return this as any
+    }
+}
+
+/**
+ *  Map of all the coins names to their respective info and price
+ */
+export interface DiaOracleModuleCoinInfosMapStorageV3 {
+    get(key: v3.Type_449): Promise<v3.CoinInfo>
+    getAll(): Promise<v3.CoinInfo[]>
+    getMany(keys: v3.Type_449[]): Promise<v3.CoinInfo[]>
+    getKeys(): Promise<v3.Type_449[]>
+    getKeys(key: v3.Type_449): Promise<v3.Type_449[]>
+    getKeysPaged(pageSize: number): AsyncIterable<v3.Type_449[]>
+    getKeysPaged(
+        pageSize: number,
+        key: v3.Type_449
+    ): AsyncIterable<v3.Type_449[]>
+    getPairs(): Promise<[k: v3.Type_449, v: v3.CoinInfo][]>
+    getPairs(key: v3.Type_449): Promise<[k: v3.Type_449, v: v3.CoinInfo][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: v3.Type_449, v: v3.CoinInfo][]>
+    getPairsPaged(
+        pageSize: number,
+        key: v3.Type_449
+    ): AsyncIterable<[k: v3.Type_449, v: v3.CoinInfo][]>
+}
+
+export class SystemAccountStorage extends StorageBase {
+    protected getPrefix() {
+        return 'System'
+    }
+
+    protected getName() {
+        return 'Account'
+    }
+
+    /**
+     *  The full account information for a particular account ID.
+     */
+    get isV1(): boolean {
+        return (
+            this.getTypeHash() ===
+            '1ddc7ade926221442c388ee4405a71c9428e548fab037445aaf4b3a78f4735c1'
+        )
+    }
+
+    /**
+     *  The full account information for a particular account ID.
+     */
+    get asV1(): SystemAccountStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  The full account information for a particular account ID.
+ */
+export interface SystemAccountStorageV1 {
+    get(key: Uint8Array): Promise<v1.AccountInfo>
+    getAll(): Promise<v1.AccountInfo[]>
+    getMany(keys: Uint8Array[]): Promise<v1.AccountInfo[]>
+    getKeys(): Promise<Uint8Array[]>
+    getKeys(key: Uint8Array): Promise<Uint8Array[]>
+    getKeysPaged(pageSize: number): AsyncIterable<Uint8Array[]>
+    getKeysPaged(pageSize: number, key: Uint8Array): AsyncIterable<Uint8Array[]>
+    getPairs(): Promise<[k: Uint8Array, v: v1.AccountInfo][]>
+    getPairs(key: Uint8Array): Promise<[k: Uint8Array, v: v1.AccountInfo][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: Uint8Array, v: v1.AccountInfo][]>
+    getPairsPaged(
+        pageSize: number,
+        key: Uint8Array
+    ): AsyncIterable<[k: Uint8Array, v: v1.AccountInfo][]>
+}
+
+export class SystemBlockHashStorage extends StorageBase {
+    protected getPrefix() {
+        return 'System'
+    }
+
+    protected getName() {
+        return 'BlockHash'
+    }
+
+    /**
+     *  Map of block numbers to block hashes.
+     */
+    get isV1(): boolean {
+        return (
+            this.getTypeHash() ===
+            '06f5703796027f4b198d4ffd50b721273430d8ff663660646793873168f9df17'
+        )
+    }
+
+    /**
+     *  Map of block numbers to block hashes.
+     */
+    get asV1(): SystemBlockHashStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Map of block numbers to block hashes.
+ */
+export interface SystemBlockHashStorageV1 {
+    get(key: number): Promise<Uint8Array>
+    getAll(): Promise<Uint8Array[]>
+    getMany(keys: number[]): Promise<Uint8Array[]>
+    getKeys(): Promise<number[]>
+    getKeys(key: number): Promise<number[]>
+    getKeysPaged(pageSize: number): AsyncIterable<number[]>
+    getKeysPaged(pageSize: number, key: number): AsyncIterable<number[]>
+    getPairs(): Promise<[k: number, v: Uint8Array][]>
+    getPairs(key: number): Promise<[k: number, v: Uint8Array][]>
+    getPairsPaged(pageSize: number): AsyncIterable<[k: number, v: Uint8Array][]>
+    getPairsPaged(
+        pageSize: number,
+        key: number
+    ): AsyncIterable<[k: number, v: Uint8Array][]>
+}
+
+export class TimestampNowStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Timestamp'
+    }
+
+    protected getName() {
+        return 'Now'
+    }
+
+    /**
+     *  Current time for the current block.
+     */
+    get isV1(): boolean {
+        return (
+            this.getTypeHash() ===
+            '95ff4f914f08e149ddbe1ae2dcb1743bbf9aaae69d04c486e1a398cacfcca06a'
+        )
+    }
+
+    /**
+     *  Current time for the current block.
+     */
+    get asV1(): TimestampNowStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+}
+
+/**
+ *  Current time for the current block.
+ */
+export interface TimestampNowStorageV1 {
+    get(): Promise<bigint>
+}
+
+export class TokensAccountsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Tokens'
+    }
+
+    protected getName() {
+        return 'Accounts'
+    }
+
+    /**
+     *  The balance of a token type under an account.
+     *
+     *  NOTE: If the total is ever zero, decrease account ref account.
+     *
+     *  NOTE: This is only used in the case that this module is used to store
+     *  balances.
+     */
+    get isV1(): boolean {
+        return (
+            this.getTypeHash() ===
+            'f741d87278aef397443c05fd06e3d212341910447aa8cc33f1f219cdc1eb052a'
+        )
+    }
+
+    /**
+     *  The balance of a token type under an account.
+     *
+     *  NOTE: If the total is ever zero, decrease account ref account.
+     *
+     *  NOTE: This is only used in the case that this module is used to store
+     *  balances.
+     */
+    get asV1(): TokensAccountsStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+
+    /**
+     *  The balance of a token type under an account.
+     *
+     *  NOTE: If the total is ever zero, decrease account ref account.
+     *
+     *  NOTE: This is only used in the case that this module is used to store
+     *  balances.
+     */
+    get isV3(): boolean {
+        return (
+            this.getTypeHash() ===
+            '447064c5cd4a4029444a7a9f7ac3619286abe5d84fbd598f1bd17ae65e70972a'
+        )
+    }
+
+    /**
+     *  The balance of a token type under an account.
+     *
+     *  NOTE: If the total is ever zero, decrease account ref account.
+     *
+     *  NOTE: This is only used in the case that this module is used to store
+     *  balances.
+     */
+    get asV3(): TokensAccountsStorageV3 {
+        assert(this.isV3)
+        return this as any
+    }
+}
+
+/**
+ *  The balance of a token type under an account.
+ *
+ *  NOTE: If the total is ever zero, decrease account ref account.
+ *
+ *  NOTE: This is only used in the case that this module is used to store
+ *  balances.
+ */
+export interface TokensAccountsStorageV1 {
+    get(key1: Uint8Array, key2: v1.CurrencyId): Promise<v1.Type_361>
+    getAll(): Promise<v1.Type_361[]>
+    getMany(keys: [Uint8Array, v1.CurrencyId][]): Promise<v1.Type_361[]>
+    getKeys(): Promise<[Uint8Array, v1.CurrencyId][]>
+    getKeys(key1: Uint8Array): Promise<[Uint8Array, v1.CurrencyId][]>
+    getKeys(
+        key1: Uint8Array,
+        key2: v1.CurrencyId
+    ): Promise<[Uint8Array, v1.CurrencyId][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[Uint8Array, v1.CurrencyId][]>
+    getKeysPaged(
+        pageSize: number,
+        key1: Uint8Array
+    ): AsyncIterable<[Uint8Array, v1.CurrencyId][]>
+    getKeysPaged(
+        pageSize: number,
+        key1: Uint8Array,
+        key2: v1.CurrencyId
+    ): AsyncIterable<[Uint8Array, v1.CurrencyId][]>
+    getPairs(): Promise<[k: [Uint8Array, v1.CurrencyId], v: v1.Type_361][]>
+    getPairs(
+        key1: Uint8Array
+    ): Promise<[k: [Uint8Array, v1.CurrencyId], v: v1.Type_361][]>
+    getPairs(
+        key1: Uint8Array,
+        key2: v1.CurrencyId
+    ): Promise<[k: [Uint8Array, v1.CurrencyId], v: v1.Type_361][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: [Uint8Array, v1.CurrencyId], v: v1.Type_361][]>
+    getPairsPaged(
+        pageSize: number,
+        key1: Uint8Array
+    ): AsyncIterable<[k: [Uint8Array, v1.CurrencyId], v: v1.Type_361][]>
+    getPairsPaged(
+        pageSize: number,
+        key1: Uint8Array,
+        key2: v1.CurrencyId
+    ): AsyncIterable<[k: [Uint8Array, v1.CurrencyId], v: v1.Type_361][]>
+}
+
+/**
+ *  The balance of a token type under an account.
+ *
+ *  NOTE: If the total is ever zero, decrease account ref account.
+ *
+ *  NOTE: This is only used in the case that this module is used to store
+ *  balances.
+ */
+export interface TokensAccountsStorageV3 {
+    get(key1: Uint8Array, key2: v3.CurrencyId): Promise<v3.Type_418>
+    getAll(): Promise<v3.Type_418[]>
+    getMany(keys: [Uint8Array, v3.CurrencyId][]): Promise<v3.Type_418[]>
+    getKeys(): Promise<[Uint8Array, v3.CurrencyId][]>
+    getKeys(key1: Uint8Array): Promise<[Uint8Array, v3.CurrencyId][]>
+    getKeys(
+        key1: Uint8Array,
+        key2: v3.CurrencyId
+    ): Promise<[Uint8Array, v3.CurrencyId][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[Uint8Array, v3.CurrencyId][]>
+    getKeysPaged(
+        pageSize: number,
+        key1: Uint8Array
+    ): AsyncIterable<[Uint8Array, v3.CurrencyId][]>
+    getKeysPaged(
+        pageSize: number,
+        key1: Uint8Array,
+        key2: v3.CurrencyId
+    ): AsyncIterable<[Uint8Array, v3.CurrencyId][]>
+    getPairs(): Promise<[k: [Uint8Array, v3.CurrencyId], v: v3.Type_418][]>
+    getPairs(
+        key1: Uint8Array
+    ): Promise<[k: [Uint8Array, v3.CurrencyId], v: v3.Type_418][]>
+    getPairs(
+        key1: Uint8Array,
+        key2: v3.CurrencyId
+    ): Promise<[k: [Uint8Array, v3.CurrencyId], v: v3.Type_418][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: [Uint8Array, v3.CurrencyId], v: v3.Type_418][]>
+    getPairsPaged(
+        pageSize: number,
+        key1: Uint8Array
+    ): AsyncIterable<[k: [Uint8Array, v3.CurrencyId], v: v3.Type_418][]>
+    getPairsPaged(
+        pageSize: number,
+        key1: Uint8Array,
+        key2: v3.CurrencyId
+    ): AsyncIterable<[k: [Uint8Array, v3.CurrencyId], v: v3.Type_418][]>
+}
+
+export class TokensTotalIssuanceStorage extends StorageBase {
+    protected getPrefix() {
+        return 'Tokens'
+    }
+
+    protected getName() {
+        return 'TotalIssuance'
+    }
+
+    /**
+     *  The total issuance of a token type.
+     */
+    get isV1(): boolean {
+        return (
+            this.getTypeHash() ===
+            '3180077969081921b1f1260f6696684789757f8c0b6adc91a41e6029dfe49428'
+        )
+    }
+
+    /**
+     *  The total issuance of a token type.
+     */
+    get asV1(): TokensTotalIssuanceStorageV1 {
+        assert(this.isV1)
+        return this as any
+    }
+
+    /**
+     *  The total issuance of a token type.
+     */
+    get isV3(): boolean {
+        return (
+            this.getTypeHash() ===
+            '856aba82a17a41f95c3ca01565e8d68de793cc4185776f58b7fb1273525d9c71'
+        )
+    }
+
+    /**
+     *  The total issuance of a token type.
+     */
+    get asV3(): TokensTotalIssuanceStorageV3 {
+        assert(this.isV3)
+        return this as any
+    }
+}
+
+/**
+ *  The total issuance of a token type.
+ */
+export interface TokensTotalIssuanceStorageV1 {
+    get(key: v1.CurrencyId): Promise<bigint>
+    getAll(): Promise<bigint[]>
+    getMany(keys: v1.CurrencyId[]): Promise<bigint[]>
+    getKeys(): Promise<v1.CurrencyId[]>
+    getKeys(key: v1.CurrencyId): Promise<v1.CurrencyId[]>
+    getKeysPaged(pageSize: number): AsyncIterable<v1.CurrencyId[]>
+    getKeysPaged(
+        pageSize: number,
+        key: v1.CurrencyId
+    ): AsyncIterable<v1.CurrencyId[]>
+    getPairs(): Promise<[k: v1.CurrencyId, v: bigint][]>
+    getPairs(key: v1.CurrencyId): Promise<[k: v1.CurrencyId, v: bigint][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: v1.CurrencyId, v: bigint][]>
+    getPairsPaged(
+        pageSize: number,
+        key: v1.CurrencyId
+    ): AsyncIterable<[k: v1.CurrencyId, v: bigint][]>
+}
+
+/**
+ *  The total issuance of a token type.
+ */
+export interface TokensTotalIssuanceStorageV3 {
+    get(key: v3.CurrencyId): Promise<bigint>
+    getAll(): Promise<bigint[]>
+    getMany(keys: v3.CurrencyId[]): Promise<bigint[]>
+    getKeys(): Promise<v3.CurrencyId[]>
+    getKeys(key: v3.CurrencyId): Promise<v3.CurrencyId[]>
+    getKeysPaged(pageSize: number): AsyncIterable<v3.CurrencyId[]>
+    getKeysPaged(
+        pageSize: number,
+        key: v3.CurrencyId
+    ): AsyncIterable<v3.CurrencyId[]>
+    getPairs(): Promise<[k: v3.CurrencyId, v: bigint][]>
+    getPairs(key: v3.CurrencyId): Promise<[k: v3.CurrencyId, v: bigint][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: v3.CurrencyId, v: bigint][]>
+    getPairsPaged(
+        pageSize: number,
+        key: v3.CurrencyId
+    ): AsyncIterable<[k: v3.CurrencyId, v: bigint][]>
+}
+
+export class ZenlinkProtocolLiquidityPairsStorage extends StorageBase {
+    protected getPrefix() {
+        return 'ZenlinkProtocol'
+    }
+
+    protected getName() {
+        return 'LiquidityPairs'
+    }
+
+    get isV3(): boolean {
+        return (
+            this.getTypeHash() ===
+            '789cf3f60e0a697e380821675a1d5385e419abba09e35755b95a3eb7b5a28f1f'
+        )
+    }
+
+    get asV3(): ZenlinkProtocolLiquidityPairsStorageV3 {
+        assert(this.isV3)
+        return this as any
+    }
+}
+
+export interface ZenlinkProtocolLiquidityPairsStorageV3 {
+    get(key: [v3.AssetId, v3.AssetId]): Promise<v3.AssetId | undefined>
+    getAll(): Promise<(v3.AssetId | undefined)[]>
+    getMany(
+        keys: [v3.AssetId, v3.AssetId][]
+    ): Promise<(v3.AssetId | undefined)[]>
+    getKeys(): Promise<[v3.AssetId, v3.AssetId][]>
+    getKeys(key: [v3.AssetId, v3.AssetId]): Promise<[v3.AssetId, v3.AssetId][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[v3.AssetId, v3.AssetId][]>
+    getKeysPaged(
+        pageSize: number,
+        key: [v3.AssetId, v3.AssetId]
+    ): AsyncIterable<[v3.AssetId, v3.AssetId][]>
+    getPairs(): Promise<
+        [k: [v3.AssetId, v3.AssetId], v: v3.AssetId | undefined][]
+    >
+    getPairs(
+        key: [v3.AssetId, v3.AssetId]
+    ): Promise<[k: [v3.AssetId, v3.AssetId], v: v3.AssetId | undefined][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: [v3.AssetId, v3.AssetId], v: v3.AssetId | undefined][]>
+    getPairsPaged(
+        pageSize: number,
+        key: [v3.AssetId, v3.AssetId]
+    ): AsyncIterable<[k: [v3.AssetId, v3.AssetId], v: v3.AssetId | undefined][]>
+}
+
+export class ZenlinkProtocolPairStatusesStorage extends StorageBase {
+    protected getPrefix() {
+        return 'ZenlinkProtocol'
+    }
+
+    protected getName() {
+        return 'PairStatuses'
+    }
+
+    /**
+     *  (T::AssetId, T::AssetId) -> PairStatus
+     */
+    get isV3(): boolean {
+        return (
+            this.getTypeHash() ===
+            'bad89eddde62d5d40bc938d63d2495e173228abf7011695d72c252612979bde7'
+        )
+    }
+
+    /**
+     *  (T::AssetId, T::AssetId) -> PairStatus
+     */
+    get asV3(): ZenlinkProtocolPairStatusesStorageV3 {
+        assert(this.isV3)
+        return this as any
+    }
+}
+
+/**
+ *  (T::AssetId, T::AssetId) -> PairStatus
+ */
+export interface ZenlinkProtocolPairStatusesStorageV3 {
+    get(key: [v3.AssetId, v3.AssetId]): Promise<v3.PairStatus>
+    getAll(): Promise<v3.PairStatus[]>
+    getMany(keys: [v3.AssetId, v3.AssetId][]): Promise<v3.PairStatus[]>
+    getKeys(): Promise<[v3.AssetId, v3.AssetId][]>
+    getKeys(key: [v3.AssetId, v3.AssetId]): Promise<[v3.AssetId, v3.AssetId][]>
+    getKeysPaged(pageSize: number): AsyncIterable<[v3.AssetId, v3.AssetId][]>
+    getKeysPaged(
+        pageSize: number,
+        key: [v3.AssetId, v3.AssetId]
+    ): AsyncIterable<[v3.AssetId, v3.AssetId][]>
+    getPairs(): Promise<[k: [v3.AssetId, v3.AssetId], v: v3.PairStatus][]>
+    getPairs(
+        key: [v3.AssetId, v3.AssetId]
+    ): Promise<[k: [v3.AssetId, v3.AssetId], v: v3.PairStatus][]>
+    getPairsPaged(
+        pageSize: number
+    ): AsyncIterable<[k: [v3.AssetId, v3.AssetId], v: v3.PairStatus][]>
+    getPairsPaged(
+        pageSize: number,
+        key: [v3.AssetId, v3.AssetId]
+    ): AsyncIterable<[k: [v3.AssetId, v3.AssetId], v: v3.PairStatus][]>
+}

--- a/src/types/pendulum/support.ts
+++ b/src/types/pendulum/support.ts
@@ -1,0 +1,201 @@
+export type Result<T, E> =
+    | {
+          __kind: 'Ok'
+          value: T
+      }
+    | {
+          __kind: 'Err'
+          value: E
+      }
+
+export type Option<T> =
+    | {
+          __kind: 'Some'
+          value: T
+      }
+    | {
+          __kind: 'None'
+      }
+
+export interface Chain {
+    getEventHash(eventName: string): string
+    decodeEvent(event: Event): any
+    getCallHash(name: string): string
+    decodeCall(call: Call): any
+    getStorageItemTypeHash(prefix: string, name: string): string | undefined
+    getStorage(
+        blockHash: string,
+        prefix: string,
+        name: string,
+        ...args: any[]
+    ): Promise<any>
+    queryStorage2(
+        blockHash: string,
+        prefix: string,
+        name: string,
+        keyList?: any[]
+    ): Promise<any[]>
+    getKeys(
+        blockHash: string,
+        prefix: string,
+        name: string,
+        ...args: any[]
+    ): Promise<any[]>
+    getPairs(
+        blockHash: string,
+        prefix: string,
+        name: string,
+        ...args: any[]
+    ): Promise<any[]>
+    getKeysPaged(
+        pageSize: number,
+        blockHash: string,
+        prefix: string,
+        name: string,
+        ...args: any[]
+    ): AsyncIterable<any[]>
+    getPairsPaged(
+        pageSize: number,
+        blockHash: string,
+        prefix: string,
+        name: string,
+        ...args: any[]
+    ): AsyncIterable<[key: any, value: any][]>
+    getConstantTypeHash(pallet: string, name: string): string | undefined
+    getConstant(pallet: string, name: string): any
+}
+
+export interface ChainContext {
+    _chain: Chain
+}
+
+export interface Event {
+    name: string
+    args: any
+}
+
+export interface EventContext extends ChainContext {
+    event: Event
+}
+
+export interface Call {
+    name: string
+    args: any
+}
+
+export interface CallContext extends ChainContext {
+    call: Call
+}
+
+export interface BlockContext extends ChainContext {
+    block: Block
+}
+
+export interface Block {
+    hash: string
+}
+
+export class StorageBase {
+    protected readonly _chain: Chain
+    protected readonly blockHash: string
+
+    constructor(ctx: BlockContext)
+    constructor(ctx: ChainContext, block: Block)
+    constructor(ctx: BlockContext, block?: Block) {
+        block = block || ctx.block
+        this.blockHash = block.hash
+        this._chain = ctx._chain
+    }
+
+    protected getPrefix(): string {
+        throw new Error('Not implemented')
+    }
+
+    protected getName(): string {
+        throw new Error('Not implemented')
+    }
+
+    protected getTypeHash(): string | undefined {
+        return this._chain.getStorageItemTypeHash(
+            this.getPrefix(),
+            this.getName()
+        )
+    }
+
+    /**
+     * Checks whether the storage item is defined for the current chain version.
+     */
+    get isExists(): boolean {
+        return this.getTypeHash() != null
+    }
+
+    protected get(...args: any[]): Promise<any> {
+        return this._chain.getStorage(
+            this.blockHash,
+            this.getPrefix(),
+            this.getName(),
+            ...args
+        )
+    }
+
+    protected getMany(keyList: any[]): Promise<any[]> {
+        return this._chain.queryStorage2(
+            this.blockHash,
+            this.getPrefix(),
+            this.getName(),
+            keyList
+        )
+    }
+
+    protected getAll(): Promise<any[]> {
+        return this._chain.queryStorage2(
+            this.blockHash,
+            this.getPrefix(),
+            this.getName()
+        )
+    }
+
+    protected getKeys(...args: any[]): Promise<any[]> {
+        return this._chain.getKeys(
+            this.blockHash,
+            this.getPrefix(),
+            this.getName(),
+            ...args
+        )
+    }
+
+    protected getKeysPaged(
+        pageSize: number,
+        ...args: any[]
+    ): AsyncIterable<any[]> {
+        return this._chain.getKeysPaged(
+            pageSize,
+            this.blockHash,
+            this.getPrefix(),
+            this.getName(),
+            ...args
+        )
+    }
+
+    protected getPairs(...args: any[]): Promise<[k: any, v: any][]> {
+        return this._chain.getPairs(
+            this.blockHash,
+            this.getPrefix(),
+            this.getName(),
+            ...args
+        )
+    }
+
+    protected getPairsPaged(
+        pageSize: number,
+        ...args: any[]
+    ): AsyncIterable<[k: any, v: any][]> {
+        return this._chain.getPairsPaged(
+            pageSize,
+            this.blockHash,
+            this.getPrefix(),
+            this.getName(),
+            ...args
+        )
+    }
+}

--- a/src/types/pendulum/v1.ts
+++ b/src/types/pendulum/v1.ts
@@ -1,0 +1,120 @@
+import type { Result, Option } from './support'
+
+export type CurrencyId = CurrencyId_Native | CurrencyId_XCM
+
+export interface CurrencyId_Native {
+    __kind: 'Native'
+}
+
+export interface CurrencyId_XCM {
+    __kind: 'XCM'
+    value: ForeignCurrencyId
+}
+
+export interface AccountInfo {
+    nonce: number
+    consumers: number
+    providers: number
+    sufficients: number
+    data: AccountData
+}
+
+export interface Type_361 {
+    free: bigint
+    reserved: bigint
+    frozen: bigint
+}
+
+export type ForeignCurrencyId =
+    | ForeignCurrencyId_KSM
+    | ForeignCurrencyId_KAR
+    | ForeignCurrencyId_AUSD
+    | ForeignCurrencyId_BNC
+    | ForeignCurrencyId_VsKSM
+    | ForeignCurrencyId_HKO
+    | ForeignCurrencyId_MOVR
+    | ForeignCurrencyId_SDN
+    | ForeignCurrencyId_KINT
+    | ForeignCurrencyId_KBTC
+    | ForeignCurrencyId_GENS
+    | ForeignCurrencyId_XOR
+    | ForeignCurrencyId_TEER
+    | ForeignCurrencyId_KILT
+    | ForeignCurrencyId_PHA
+    | ForeignCurrencyId_ZTG
+    | ForeignCurrencyId_USD
+
+export interface ForeignCurrencyId_KSM {
+    __kind: 'KSM'
+}
+
+export interface ForeignCurrencyId_KAR {
+    __kind: 'KAR'
+}
+
+export interface ForeignCurrencyId_AUSD {
+    __kind: 'AUSD'
+}
+
+export interface ForeignCurrencyId_BNC {
+    __kind: 'BNC'
+}
+
+export interface ForeignCurrencyId_VsKSM {
+    __kind: 'VsKSM'
+}
+
+export interface ForeignCurrencyId_HKO {
+    __kind: 'HKO'
+}
+
+export interface ForeignCurrencyId_MOVR {
+    __kind: 'MOVR'
+}
+
+export interface ForeignCurrencyId_SDN {
+    __kind: 'SDN'
+}
+
+export interface ForeignCurrencyId_KINT {
+    __kind: 'KINT'
+}
+
+export interface ForeignCurrencyId_KBTC {
+    __kind: 'KBTC'
+}
+
+export interface ForeignCurrencyId_GENS {
+    __kind: 'GENS'
+}
+
+export interface ForeignCurrencyId_XOR {
+    __kind: 'XOR'
+}
+
+export interface ForeignCurrencyId_TEER {
+    __kind: 'TEER'
+}
+
+export interface ForeignCurrencyId_KILT {
+    __kind: 'KILT'
+}
+
+export interface ForeignCurrencyId_PHA {
+    __kind: 'PHA'
+}
+
+export interface ForeignCurrencyId_ZTG {
+    __kind: 'ZTG'
+}
+
+export interface ForeignCurrencyId_USD {
+    __kind: 'USD'
+}
+
+export interface AccountData {
+    free: bigint
+    reserved: bigint
+    miscFrozen: bigint
+    feeFrozen: bigint
+}

--- a/src/types/pendulum/v3.ts
+++ b/src/types/pendulum/v3.ts
@@ -1,0 +1,70 @@
+import type { Result, Option } from './support'
+
+export interface CoinInfo {
+    symbol: Uint8Array
+    name: Uint8Array
+    blockchain: Uint8Array
+    supply: bigint
+    lastUpdateTimestamp: bigint
+    price: bigint
+}
+
+export type CurrencyId = CurrencyId_Native | CurrencyId_XCM
+
+export interface CurrencyId_Native {
+    __kind: 'Native'
+}
+
+export interface CurrencyId_XCM {
+    __kind: 'XCM'
+    value: number
+}
+
+export interface AssetId {
+    chainId: number
+    assetType: number
+    assetIndex: bigint
+}
+
+export interface Type_449 {
+    blockchain: Uint8Array
+    symbol: Uint8Array
+}
+
+export interface Type_418 {
+    free: bigint
+    reserved: bigint
+    frozen: bigint
+}
+
+export type PairStatus =
+    | PairStatus_Trading
+    | PairStatus_Bootstrap
+    | PairStatus_Disable
+
+export interface PairStatus_Trading {
+    __kind: 'Trading'
+    value: PairMetadata
+}
+
+export interface PairStatus_Bootstrap {
+    __kind: 'Bootstrap'
+    value: BootstrapParameter
+}
+
+export interface PairStatus_Disable {
+    __kind: 'Disable'
+}
+
+export interface PairMetadata {
+    pairAccount: Uint8Array
+    totalSupply: bigint
+}
+
+export interface BootstrapParameter {
+    targetSupply: [bigint, bigint]
+    capacitySupply: [bigint, bigint]
+    accumulatedSupply: [bigint, bigint]
+    endBlockNumber: number
+    pairAccount: Uint8Array
+}

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,9 +1,15 @@
 import * as amplitudeStorage from './amplitude/storage'
 import * as foucocoStorage from './foucoco/storage'
+import * as pendulumStorage from './pendulum/storage'
 import { network } from '../config'
 
-const storage = network === 'foucoco' ? foucocoStorage : amplitudeStorage
+const storage =
+    network === 'foucoco'
+        ? foucocoStorage
+        : network === 'amplitude'
+        ? amplitudeStorage
+        : pendulumStorage
 
-export { amplitudeStorage, foucocoStorage }
+export { amplitudeStorage, foucocoStorage, pendulumStorage }
 
 export default storage

--- a/src/utils/farming.ts
+++ b/src/utils/farming.ts
@@ -27,6 +27,7 @@ export function formatFarmingCreatedPoolEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingFarmingPoolCreatedEvent(
             ctx,
             ctx.event
@@ -49,6 +50,7 @@ export function formatFarmingPoolResetEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingFarmingPoolResetEvent(
             ctx,
             ctx.event
@@ -71,6 +73,7 @@ export function formatFarmingPoolClosedEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingFarmingPoolClosedEvent(
             ctx,
             ctx.event
@@ -93,6 +96,7 @@ export function formatFarmingPoolKilledEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingFarmingPoolKilledEvent(
             ctx,
             ctx.event
@@ -115,6 +119,7 @@ export function formatFarmingPoolEditedEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingFarmingPoolEditedEvent(
             ctx,
             ctx.event
@@ -137,6 +142,7 @@ export function formatFarmingChargedEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingChargedEvent(ctx, ctx.event)
         event = _event.asV1
     } else {
@@ -156,6 +162,7 @@ export function formatFarmingDepositedEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingDepositedEvent(ctx, ctx.event)
         event = _event.asV1
     } else {
@@ -175,6 +182,7 @@ export function formatFarmingWithdrawnEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingWithdrawnEvent(ctx, ctx.event)
         event = _event.asV1
     } else {
@@ -194,6 +202,7 @@ export function formatFarmingClaimedEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingClaimedEvent(ctx, ctx.event)
         event = _event.asV1
     } else {
@@ -213,6 +222,7 @@ export function formatFarmingWithdrawClaimedEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingWithdrawClaimedEvent(
             ctx,
             ctx.event
@@ -235,6 +245,7 @@ export function formatFarmingGaugeWithdrawnEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingGaugeWithdrawnEvent(
             ctx,
             ctx.event
@@ -259,6 +270,7 @@ export function formatFarmingAllForceGaugeClaimedEvent(
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingAllForceGaugeClaimedEvent(
             ctx,
             ctx.event
@@ -285,6 +297,7 @@ export function formatFarmingPartiallyForceGaugeClaimedEvent(
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingPartiallyForceGaugeClaimedEvent(
             ctx,
             ctx.event
@@ -308,6 +321,7 @@ export function formatFarmingAllRetiredEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingAllRetiredEvent(ctx, ctx.event)
         event = _event.asV1
     } else {
@@ -327,6 +341,7 @@ export function formatFarmingPartiallyRetiredEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingPartiallyRetiredEvent(
             ctx,
             ctx.event
@@ -349,6 +364,7 @@ export function formatFarmingRetireLimitSetEvent(ctx: EventHandlerContext) {
             event = _event.asV1
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoEvents to pendulumEvents when the farming pallet is implemented on pendulum.
         const _event = new foucocoEvents.FarmingRetireLimitSetEvent(
             ctx,
             ctx.event
@@ -378,6 +394,7 @@ export async function getFamingPoolInfo(
             result = await farmingPoolInfoStorage.asV1.get(pid)
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoStorage to pendulumStorage when the farming pallet is implemented on pendulum.
         const farmingPoolInfoStorage =
             new foucocoStorage.FarmingPoolInfosStorage(ctx, block)
         if (farmingPoolInfoStorage.isV1) {
@@ -410,6 +427,7 @@ export async function getFamingSharesAndWithdrawnRewards(
             result = await storage.asV1.get(pid, user)
         }
     } else if (network === 'pendulum') {
+        // FIXME: Change foucocoStorage to pendulumStorage when the farming pallet is implemented on pendulum.
         const storage =
             new foucocoStorage.FarmingSharesAndWithdrawnRewardsStorage(
                 ctx,

--- a/src/utils/farming.ts
+++ b/src/utils/farming.ts
@@ -26,6 +26,12 @@ export function formatFarmingCreatedPoolEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network == 'pendulum') {
+        const _event = new foucocoEvents.FarmingFarmingPoolCreatedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingFarmingPoolCreatedEvent(ctx)
         if (_event.isV10) {

--- a/src/utils/farming.ts
+++ b/src/utils/farming.ts
@@ -26,7 +26,7 @@ export function formatFarmingCreatedPoolEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
-    } else if (network == 'pendulum') {
+    } else if (network === 'pendulum') {
         const _event = new foucocoEvents.FarmingFarmingPoolCreatedEvent(
             ctx,
             ctx.event
@@ -48,6 +48,12 @@ export function formatFarmingPoolResetEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingFarmingPoolResetEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingFarmingPoolResetEvent(ctx)
         if (_event.isV10) {
@@ -64,6 +70,12 @@ export function formatFarmingPoolClosedEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingFarmingPoolClosedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingFarmingPoolClosedEvent(ctx)
         if (_event.isV10) {
@@ -80,6 +92,12 @@ export function formatFarmingPoolKilledEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingFarmingPoolKilledEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingFarmingPoolKilledEvent(ctx)
         if (_event.isV10) {
@@ -96,6 +114,12 @@ export function formatFarmingPoolEditedEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingFarmingPoolEditedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingFarmingPoolEditedEvent(ctx)
         if (_event.isV10) {
@@ -112,6 +136,9 @@ export function formatFarmingChargedEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingChargedEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingChargedEvent(ctx)
         if (_event.isV10) {
@@ -128,6 +155,9 @@ export function formatFarmingDepositedEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingDepositedEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingDepositedEvent(ctx)
         if (_event.isV10) {
@@ -144,6 +174,9 @@ export function formatFarmingWithdrawnEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingWithdrawnEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingWithdrawnEvent(ctx)
         if (_event.isV10) {
@@ -160,6 +193,9 @@ export function formatFarmingClaimedEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingClaimedEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingClaimedEvent(ctx)
         if (_event.isV10) {
@@ -176,6 +212,12 @@ export function formatFarmingWithdrawClaimedEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingWithdrawClaimedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingWithdrawClaimedEvent(ctx)
         if (_event.isV10) {
@@ -192,6 +234,12 @@ export function formatFarmingGaugeWithdrawnEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingGaugeWithdrawnEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingGaugeWithdrawnEvent(ctx)
         if (_event.isV10) {
@@ -210,6 +258,12 @@ export function formatFarmingAllForceGaugeClaimedEvent(
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingAllForceGaugeClaimedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingAllForceGaugeClaimedEvent(ctx)
         if (_event.isV10) {
@@ -230,6 +284,12 @@ export function formatFarmingPartiallyForceGaugeClaimedEvent(
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingPartiallyForceGaugeClaimedEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event =
             new amplitudeEvents.FarmingPartiallyForceGaugeClaimedEvent(ctx)
@@ -247,6 +307,9 @@ export function formatFarmingAllRetiredEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingAllRetiredEvent(ctx, ctx.event)
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingAllRetiredEvent(ctx)
         if (_event.isV10) {
@@ -263,6 +326,12 @@ export function formatFarmingPartiallyRetiredEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingPartiallyRetiredEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingPartiallyRetiredEvent(ctx)
         if (_event.isV10) {
@@ -279,6 +348,12 @@ export function formatFarmingRetireLimitSetEvent(ctx: EventHandlerContext) {
         if (_event.isV1) {
             event = _event.asV1
         }
+    } else if (network === 'pendulum') {
+        const _event = new foucocoEvents.FarmingRetireLimitSetEvent(
+            ctx,
+            ctx.event
+        )
+        event = _event.asV1
     } else {
         const _event = new amplitudeEvents.FarmingRetireLimitSetEvent(ctx)
         if (_event.isV10) {
@@ -302,6 +377,12 @@ export async function getFamingPoolInfo(
         if (farmingPoolInfoStorage.isV1) {
             result = await farmingPoolInfoStorage.asV1.get(pid)
         }
+    } else if (network === 'pendulum') {
+        const farmingPoolInfoStorage =
+            new foucocoStorage.FarmingPoolInfosStorage(ctx, block)
+        if (farmingPoolInfoStorage.isV1) {
+            result = await farmingPoolInfoStorage.asV1.get(pid)
+        }
     } else {
         const farmingPoolInfoStorage =
             new amplitudeStorage.FarmingPoolInfosStorage(ctx, block)
@@ -320,6 +401,15 @@ export async function getFamingSharesAndWithdrawnRewards(
     let result
 
     if (network === 'foucoco') {
+        const storage =
+            new foucocoStorage.FarmingSharesAndWithdrawnRewardsStorage(
+                ctx,
+                ctx.block
+            )
+        if (storage.isV1) {
+            result = await storage.asV1.get(pid, user)
+        }
+    } else if (network === 'pendulum') {
         const storage =
             new foucocoStorage.FarmingSharesAndWithdrawnRewardsStorage(
                 ctx,

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,5 +1,9 @@
 import { EventHandlerContext } from '../types'
-import { amplitudeStorage, foucocoStorage } from '../types/storage'
+import {
+    amplitudeStorage,
+    foucocoStorage,
+    pendulumStorage,
+} from '../types/storage'
 import { AssetId, CurrencyId } from '../types/common'
 import { codec } from '@subsquid/ss58'
 import { config, network } from '../config'
@@ -232,6 +236,13 @@ export async function getPairAssetIdFromAssets(
                         ctx.block
                     )
                 versionStorage = baseStorage.asV1
+            } else if (network === 'pendulum') {
+                baseStorage =
+                    new pendulumStorage.ZenlinkProtocolLiquidityPairsStorage(
+                        ctx,
+                        ctx.block
+                    )
+                versionStorage = baseStorage.asV3
             } else {
                 baseStorage =
                     new amplitudeStorage.ZenlinkProtocolLiquidityPairsStorage(
@@ -277,6 +288,13 @@ export async function getPairStatusFromAssets(
                         ctx.block
                     )
                 versionStorage = baseStorage.asV1
+            } else if (network === 'pendulum') {
+                baseStorage =
+                    new pendulumStorage.ZenlinkProtocolPairStatusesStorage(
+                        ctx,
+                        ctx.block
+                    )
+                versionStorage = baseStorage.asV3
             } else {
                 baseStorage =
                     new amplitudeStorage.ZenlinkProtocolPairStatusesStorage(
@@ -311,6 +329,8 @@ export async function getTokenBalance(
             if (network === 'foucoco') {
                 return new foucocoStorage.SystemAccountStorage(ctx, ctx.block)
                     .asV1
+            } else if (network === 'pendulum') {
+                return new pendulumStorage.SystemAccountStorage(ctx, ctx.block)
             } else {
                 return new amplitudeStorage.SystemAccountStorage(ctx, ctx.block)
                     .asV1
@@ -325,6 +345,20 @@ export async function getTokenBalance(
                 account,
                 assetId as any
             )
+        } else if (network === 'pendulum') {
+            const tokenAccountsStorage =
+                new pendulumStorage.TokensAccountsStorage(ctx, ctx.block)
+            if (tokenAccountsStorage.isV1) {
+                result = await tokenAccountsStorage.asV1.get(
+                    account,
+                    assetId as any
+                )
+            } else {
+                result = await tokenAccountsStorage.asV3.get(
+                    account,
+                    assetId as any
+                )
+            }
         } else {
             const tokenAccountsStorage =
                 new amplitudeStorage.TokensAccountsStorage(ctx, ctx.block)
@@ -363,6 +397,11 @@ export async function getTotalIssuance(
                     ctx,
                     ctx.block
                 ).asV1
+            } else if (network === 'pendulum') {
+                return new pendulumStorage.BalancesTotalIssuanceStorage(
+                    ctx,
+                    ctx.block
+                ).asV1
             } else {
                 return new amplitudeStorage.BalancesTotalIssuanceStorage(
                     ctx,
@@ -375,6 +414,11 @@ export async function getTotalIssuance(
         if (network === 'foucoco') {
             const tokenIssuanceStorage =
                 new foucocoStorage.TokensTotalIssuanceStorage(ctx, ctx.block)
+                    .asV1
+            result = await tokenIssuanceStorage.get(assetId as any)
+        } else if (network === 'pendulum') {
+            const tokenIssuanceStorage =
+                new pendulumStorage.TokensTotalIssuanceStorage(ctx, ctx.block)
                     .asV1
             result = await tokenIssuanceStorage.get(assetId as any)
         } else {
@@ -407,6 +451,9 @@ export async function getTokenBurned(
             if (network === 'foucoco') {
                 return new foucocoStorage.SystemAccountStorage(ctx, ctx.block)
                     .asV1
+            } else if (network === 'pendulum') {
+                return new pendulumStorage.SystemAccountStorage(ctx, ctx.block)
+                    .asV1
             } else {
                 return new amplitudeStorage.SystemAccountStorage(ctx, ctx.block)
                     .asV1
@@ -417,6 +464,10 @@ export async function getTokenBurned(
         if (network === 'foucoco') {
             const tokenAccountsStorage =
                 new foucocoStorage.TokensAccountsStorage(ctx, block).asV1
+            result = await tokenAccountsStorage.get(account, assetId as any)
+        } else if (network === 'pendulum') {
+            const tokenAccountsStorage =
+                new pendulumStorage.TokensAccountsStorage(ctx, block).asV1
             result = await tokenAccountsStorage.get(account, assetId as any)
         } else {
             const tokenAccountsStorage =

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -331,6 +331,7 @@ export async function getTokenBalance(
                     .asV1
             } else if (network === 'pendulum') {
                 return new pendulumStorage.SystemAccountStorage(ctx, ctx.block)
+                    .asV1
             } else {
                 return new amplitudeStorage.SystemAccountStorage(ctx, ctx.block)
                     .asV1

--- a/typegen-pendulum.json
+++ b/typegen-pendulum.json
@@ -11,22 +11,6 @@
 
         "DiaOracleModule.UpdatedPrices",
 
-        "Farming.FarmingPoolCreated",
-        "Farming.FarmingPoolReset",
-        "Farming.FarmingPoolClosed",
-        "Farming.FarmingPoolKilled",
-        "Farming.FarmingPoolEdited",
-        "Farming.Charged",
-        "Farming.Deposited",
-        "Farming.Withdrawn",
-        "Farming.Claimed",
-        "Farming.WithdrawClaimed",
-        "Farming.GaugeWithdrawn",
-        "Farming.AllForceGaugeClaimed",
-        "Farming.PartiallyForceGaugeClaimed",
-        "Farming.AllRetired",
-        "Farming.PartiallyRetired",
-        "Farming.RetireLimitSet",
         "ZenlinkProtocol.AssetSwap",
         "ZenlinkProtocol.LiquidityAdded",
         "ZenlinkProtocol.LiquidityRemoved"
@@ -42,10 +26,6 @@
 
         "DiaOracleModule.CoinInfosMap",
 
-        "Farming.PoolInfos",
-        "Farming.GaugePoolInfos",
-        "Farming.GaugeInfos",
-        "Farming.SharesAndWithdrawnRewards",
         "ZenlinkProtocol.PairStatuses",
         "ZenlinkProtocol.LiquidityPairs"
     ]

--- a/typegen-pendulum.json
+++ b/typegen-pendulum.json
@@ -1,0 +1,52 @@
+{
+    "outDir": "src/types/pendulum",
+    "specVersions": "https://pendulum.archive.subsquid.io/graphql",
+    "events": [
+        "Balances.Transfer",
+
+        "Tokens.Transfer",
+        "Tokens.Deposited",
+        "Tokens.Withdrawn",
+        "Tokens.BalanceSet",
+
+        "DiaOracleModule.UpdatedPrices",
+
+        "Farming.FarmingPoolCreated",
+        "Farming.FarmingPoolReset",
+        "Farming.FarmingPoolClosed",
+        "Farming.FarmingPoolKilled",
+        "Farming.FarmingPoolEdited",
+        "Farming.Charged",
+        "Farming.Deposited",
+        "Farming.Withdrawn",
+        "Farming.Claimed",
+        "Farming.WithdrawClaimed",
+        "Farming.GaugeWithdrawn",
+        "Farming.AllForceGaugeClaimed",
+        "Farming.PartiallyForceGaugeClaimed",
+        "Farming.AllRetired",
+        "Farming.PartiallyRetired",
+        "Farming.RetireLimitSet",
+        "ZenlinkProtocol.AssetSwap",
+        "ZenlinkProtocol.LiquidityAdded",
+        "ZenlinkProtocol.LiquidityRemoved"
+    ],
+    "calls": [],
+    "storage": [
+        "Balances.TotalIssuance",
+        "System.Account",
+        "System.BlockHash",
+        "Timestamp.Now",
+        "Tokens.Accounts",
+        "Tokens.TotalIssuance",
+
+        "DiaOracleModule.CoinInfosMap",
+
+        "Farming.PoolInfos",
+        "Farming.GaugePoolInfos",
+        "Farming.GaugeInfos",
+        "Farming.SharesAndWithdrawnRewards",
+        "ZenlinkProtocol.PairStatuses",
+        "ZenlinkProtocol.LiquidityPairs"
+    ]
+}


### PR DESCRIPTION
Issue #14

This PR has the basic configuration for the pendulum squid.

In the future, we could need to handle the farming pallet events for the pendulum chain too. A draft event handling was added to the farming utils [file](https://github.com/pendulum-chain/pendulum-squids/blob/b66c0f4ee6c02ee5ec67cdb9ff36288a10bcd5c6/src/utils/farming.ts#L29C7-L35C7) (for example [here](https://github.com/pendulum-chain/pendulum-squids/blob/b66c0f4ee6c02ee5ec67cdb9ff36288a10bcd5c6/src/utils/farming.ts#L29C7-L35C7)). Basically, the foucoco event types were used. That would need to be changed in the future, when the farming pallet is implemented on pendulum.