### PR TITLE
Fix for sorting pairs before querying the storage

### DIFF
--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 16
+version: 17
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 17
+version: 18
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/squid-foucoco.yaml
+++ b/squid-foucoco.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: foucoco-squid
-version: 17
+version: 18
 description: 'Foucoco Squid'
 build:
 deploy:

--- a/squid-foucoco.yaml
+++ b/squid-foucoco.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: foucoco-squid
-version: 16
+version: 17
 description: 'Foucoco Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 17
+version: 18
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/src/mappings/protocol.ts
+++ b/src/mappings/protocol.ts
@@ -11,7 +11,6 @@ import {
     getTokenBalance,
     getTokenBurned,
     zenlinkAssetIdToCurrencyId,
-    sortAndCheckIfSwitched,
 } from '../utils/token'
 import { ZERO_BD } from '../constants'
 import { codec } from '@subsquid/ss58'
@@ -31,6 +30,7 @@ import {
     updateZenlinkInfo,
 } from '../utils/updates'
 import { decodeEvent } from '../types/eventsAndStorageSelector'
+import { getOrCreateToken } from '../entities/token'
 
 export async function handleLiquiditySync(
     ctx: EventHandlerContext,
@@ -42,7 +42,7 @@ export async function handleLiquiditySync(
     const asset0 = assetIdFromAddress(token0.id)
     const asset1 = assetIdFromAddress(token1.id)
 
-    let { sortedPair } = sortAndCheckIfSwitched([asset0, asset1])
+    const sortedPair = sortAssets([asset0, asset1])
     const [pairAccount] = await getPairStatusFromAssets(ctx, sortedPair)
 
     if (!pairAccount) return
@@ -316,14 +316,11 @@ export async function handleAssetSwap(ctx: EventHandlerContext) {
     const to = codec(config.prefix).encode(event[1])
 
     for (let i = 1; i < path.length; i++) {
-        const asset0 = path[i - 1]
-        const asset1 = path[i]
+        const inputAsset = path[i - 1]
+        const outputAsset = path[i]
+        const [asset0, asset1] = sortAssets([inputAsset, outputAsset])
 
-        let { sortedPair, isSwitched } = sortAndCheckIfSwitched([
-            asset0,
-            asset1,
-        ])
-        const pair = await getPair(ctx, sortedPair)
+        const pair = await getPair(ctx, [asset0, asset1])
 
         if (!pair) return
         await handleLiquiditySync(ctx, pair)
@@ -343,17 +340,18 @@ export async function handleAssetSwap(ctx: EventHandlerContext) {
             amount1Out = ZERO_BD
 
         // We need to check if the order of assets in the pair was switched, so we can correctly assign the amounts
-        const rawAmount0In = isSwitched ? 0n : amounts[i - 1]
-        const rawAmount1In = isSwitched ? amounts[i - 1] : 0n
-        const rawAmount0Out = isSwitched ? amounts[i] : 0n
-        const rawAmount1Out = isSwitched ? 0n : amounts[i]
+        const inputToken = await getOrCreateToken(ctx, inputAsset)
+        const [amount0, amount1] =
+            inputToken?.id === token0.id
+                ? [amounts[i - 1], amounts[i]]
+                : [amounts[i], amounts[i - 1]]
 
-        amount0In = convertTokenToDecimal(rawAmount0In, token0.decimals)
-        amount0Out = convertTokenToDecimal(rawAmount0Out, token0.decimals)
+        amount0In = convertTokenToDecimal(amount0, token0.decimals)
+        amount0Out = convertTokenToDecimal(0n, token0.decimals)
         amount0Total = amount0Out.plus(amount0In)
 
-        amount1In = convertTokenToDecimal(rawAmount1In, token1.decimals)
-        amount1Out = convertTokenToDecimal(rawAmount1Out, token1.decimals)
+        amount1In = convertTokenToDecimal(0n, token1.decimals)
+        amount1Out = convertTokenToDecimal(amount1, token1.decimals)
         amount1Total = amount1Out.plus(amount1In)
 
         // get total amounts of derived USD and ETH for tracking

--- a/src/mappings/protocol.ts
+++ b/src/mappings/protocol.ts
@@ -309,7 +309,6 @@ export async function handleAssetSwap(ctx: EventHandlerContext) {
     if (!txHash) return
 
     let event = decodeEvent(network, ctx, 'zenlinkProtocol', 'assetSwap')
-    console.log(event)
     const path = event[2]
     const amounts = event[3]
     const sender = codec(config.prefix).encode(event[0])

--- a/src/mappings/protocol.ts
+++ b/src/mappings/protocol.ts
@@ -341,17 +341,20 @@ export async function handleAssetSwap(ctx: EventHandlerContext) {
 
         // We need to check if the order of assets in the pair was switched, so we can correctly assign the amounts
         const inputToken = await getOrCreateToken(ctx, inputAsset)
-        const [amount0, amount1] =
-            inputToken?.id === token0.id
-                ? [amounts[i - 1], amounts[i]]
-                : [amounts[i], amounts[i - 1]]
+        const isSwitched = !(inputToken?.id === token0.id)
 
-        amount0In = convertTokenToDecimal(amount0, token0.decimals)
-        amount0Out = convertTokenToDecimal(0n, token0.decimals)
+        // We need to check if the order of assets in the pair was switched, so we can correctly assign the amounts
+        const rawAmount0In = isSwitched ? 0n : amounts[i - 1]
+        const rawAmount1In = isSwitched ? amounts[i - 1] : 0n
+        const rawAmount0Out = isSwitched ? amounts[i] : 0n
+        const rawAmount1Out = isSwitched ? 0n : amounts[i]
+
+        amount0In = convertTokenToDecimal(rawAmount0In, token0.decimals)
+        amount0Out = convertTokenToDecimal(rawAmount0Out, token0.decimals)
         amount0Total = amount0Out.plus(amount0In)
 
-        amount1In = convertTokenToDecimal(0n, token1.decimals)
-        amount1Out = convertTokenToDecimal(amount1, token1.decimals)
+        amount1In = convertTokenToDecimal(rawAmount1In, token1.decimals)
+        amount1Out = convertTokenToDecimal(rawAmount1Out, token1.decimals)
         amount1Total = amount1Out.plus(amount1In)
 
         // get total amounts of derived USD and ETH for tracking

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -21,13 +21,11 @@ import {
     Transaction,
     User,
 } from '../model'
-import {
-    getPairStatusFromAssets,
-    getTokenBalance,
-    sortAndCheckIfSwitched,
-} from '../utils/token'
+import { getPairStatusFromAssets, getTokenBalance } from '../utils/token'
 import { StrKey } from 'stellar-base'
 import { decodeEvent } from '../types/eventsAndStorageSelector'
+import { sortAssets } from '../utils/sort'
+
 async function isCompleteMint(
     ctx: EventHandlerContext,
     mintId: string
@@ -43,6 +41,7 @@ function hexAssetCodeToString(code: string) {
 
     return code
 }
+
 function trimCode(code: string): string {
     if (code.startsWith('0x')) {
         // Filter out the null bytes
@@ -199,7 +198,7 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
         await ctx.store.save(transaction)
     }
 
-    let { sortedPair } = sortAndCheckIfSwitched([asset0, asset1])
+    const sortedPair = sortAssets([asset0, asset1])
     pair.totalSupply = (
         await getPairStatusFromAssets(ctx, sortedPair, false)
     )[1].toString()
@@ -301,7 +300,7 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
         await ctx.store.save(transaction)
     }
 
-    let { sortedPair, isSwitched } = sortAndCheckIfSwitched([asset0, asset1])
+    const sortedPair = sortAssets([asset0, asset1])
     pair.totalSupply = (
         await getPairStatusFromAssets(ctx, sortedPair, false)
     )[1].toString()

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -199,15 +199,15 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
         await ctx.store.save(transaction)
     }
 
-    let { sortedPairs, isSwitched } = sortAndCheckIfSwitched([asset0, asset1])
+    let { sortedPair } = sortAndCheckIfSwitched([asset0, asset1])
     pair.totalSupply = (
-        await getPairStatusFromAssets(ctx, sortedPairs, false)
+        await getPairStatusFromAssets(ctx, sortedPair, false)
     )[1].toString()
 
     const { mints } = transaction
 
     pair.totalSupply = (
-        await getPairStatusFromAssets(ctx, sortedPairs, false)
+        await getPairStatusFromAssets(ctx, sortedPair, false)
     )[1].toString()
     if (!mints.length || (await isCompleteMint(ctx, mints[mints.length - 1]))) {
         const mint = new Mint({
@@ -301,9 +301,9 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
         await ctx.store.save(transaction)
     }
 
-    let { sortedPairs, isSwitched } = sortAndCheckIfSwitched([asset0, asset1])
+    let { sortedPair, isSwitched } = sortAndCheckIfSwitched([asset0, asset1])
     pair.totalSupply = (
-        await getPairStatusFromAssets(ctx, sortedPairs, false)
+        await getPairStatusFromAssets(ctx, sortedPair, false)
     )[1].toString()
     const { burns, mints } = transaction
     let burn: Burn

--- a/src/mappings/token.ts
+++ b/src/mappings/token.ts
@@ -21,7 +21,11 @@ import {
     Transaction,
     User,
 } from '../model'
-import { getPairStatusFromAssets, getTokenBalance } from '../utils/token'
+import {
+    getPairStatusFromAssets,
+    getTokenBalance,
+    sortAndCheckIfSwitched,
+} from '../utils/token'
 import { StrKey } from 'stellar-base'
 import { decodeEvent } from '../types/eventsAndStorageSelector'
 async function isCompleteMint(
@@ -195,14 +199,15 @@ export async function handleTokenDeposited(ctx: EventHandlerContext) {
         await ctx.store.save(transaction)
     }
 
+    let { sortedPairs, isSwitched } = sortAndCheckIfSwitched([asset0, asset1])
     pair.totalSupply = (
-        await getPairStatusFromAssets(ctx, [asset0, asset1], false)
+        await getPairStatusFromAssets(ctx, sortedPairs, false)
     )[1].toString()
 
     const { mints } = transaction
 
     pair.totalSupply = (
-        await getPairStatusFromAssets(ctx, [asset0, asset1], false)
+        await getPairStatusFromAssets(ctx, sortedPairs, false)
     )[1].toString()
     if (!mints.length || (await isCompleteMint(ctx, mints[mints.length - 1]))) {
         const mint = new Mint({
@@ -296,8 +301,9 @@ export async function handleTokenWithdrawn(ctx: EventHandlerContext) {
         await ctx.store.save(transaction)
     }
 
+    let { sortedPairs, isSwitched } = sortAndCheckIfSwitched([asset0, asset1])
     pair.totalSupply = (
-        await getPairStatusFromAssets(ctx, [asset0, asset1], false)
+        await getPairStatusFromAssets(ctx, sortedPairs, false)
     )[1].toString()
     const { burns, mints } = transaction
     let burn: Burn

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -370,3 +370,27 @@ export async function getTokenBurned(
 
     return result?.free
 }
+
+export function sortAndCheckIfSwitched(entries: [AssetId, AssetId]): {
+    sortedPairs: [AssetId, AssetId]
+    isSwitched: boolean
+} {
+    const originalEntries = [...entries]
+
+    const sortedPairs = entries.sort((a, b) => {
+        if (a.assetType < b.assetType) return -1
+        if (a.assetType > b.assetType) return 1
+
+        if (a.assetIndex < b.assetIndex) return -1
+        if (a.assetIndex > b.assetIndex) return 1
+
+        return 0
+    })
+
+    // check if any order was switched by comparing the sorted array to the original
+    const isSwitched = !sortedPairs.every(
+        (item, index) => item === originalEntries[index]
+    )
+
+    return { sortedPairs, isSwitched }
+}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -5,6 +5,7 @@ import { config, network } from '../config'
 import { invert } from 'lodash'
 import { hexToU8a } from '@polkadot/util'
 import { getVersionedStorage } from '../types/eventsAndStorageSelector'
+
 export const currencyKeyMap: { [index: number]: string } = {
     0: 'Native',
     1: 'XCM',
@@ -31,6 +32,7 @@ function versionedCurrencyToCurrencyEnum(
             throw new Error('Invalid currency type')
     }
 }
+
 export enum CurrencyTypeEnum {
     Native = 0,
     XCM = 1,
@@ -369,28 +371,4 @@ export async function getTokenBurned(
     }
 
     return result?.free
-}
-
-export function sortAndCheckIfSwitched(entries: [AssetId, AssetId]): {
-    sortedPair: [AssetId, AssetId]
-    isSwitched: boolean
-} {
-    const originalEntries = [...entries]
-
-    const sortedPair = entries.sort((a, b) => {
-        if (a.assetType < b.assetType) return -1
-        if (a.assetType > b.assetType) return 1
-
-        if (a.assetIndex < b.assetIndex) return -1
-        if (a.assetIndex > b.assetIndex) return 1
-
-        return 0
-    })
-
-    // check if any order was switched by comparing the sorted array to the original
-    const isSwitched = !sortedPair.every(
-        (item, index) => item === originalEntries[index]
-    )
-
-    return { sortedPair, isSwitched }
 }

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -372,12 +372,12 @@ export async function getTokenBurned(
 }
 
 export function sortAndCheckIfSwitched(entries: [AssetId, AssetId]): {
-    sortedPairs: [AssetId, AssetId]
+    sortedPair: [AssetId, AssetId]
     isSwitched: boolean
 } {
     const originalEntries = [...entries]
 
-    const sortedPairs = entries.sort((a, b) => {
+    const sortedPair = entries.sort((a, b) => {
         if (a.assetType < b.assetType) return -1
         if (a.assetType > b.assetType) return 1
 
@@ -388,9 +388,9 @@ export function sortAndCheckIfSwitched(entries: [AssetId, AssetId]): {
     })
 
     // check if any order was switched by comparing the sorted array to the original
-    const isSwitched = !sortedPairs.every(
+    const isSwitched = !sortedPair.every(
         (item, index) => item === originalEntries[index]
     )
 
-    return { sortedPairs, isSwitched }
+    return { sortedPair, isSwitched }
 }


### PR DESCRIPTION
A bug was identified where the [lookup](https://github.com/pendulum-chain/pendulum-squids/blob/1a942272345091fdebf32be6ef5d692212de7aee/src/entities/pair.ts#L33) of the pair given an event swap was not returning the pair, and therefore not indexing the swap.

 Since `getPairAssetIdFromAssets` calls the [storage](https://github.com/pendulum-chain/pendulum-squids/blob/1a942272345091fdebf32be6ef5d692212de7aee/src/utils/token.ts#L246), at this point we need to sort the assets the same way the zenlink pallet does.

The rest of the changes are to adapt the code so that even when we have to reorder the pairs, we are consistent with the `asset0`, `asset1` naming and convention. For example, `amount0In` should always correspond to the input amount into the swap of the first asset **after they are sorted**.

Closes #57.