### PR TITLE
Regenerate types after runtime upgrade.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ To deploy the squid to the production environment you should run the following c
 
 ```shell
 # Replace {version} with the version you define in the `squid.yaml` file
-sqd prod pendulum-squid@{version}
-sqd prod amplitude-squid@{version}
-sqd prod foucoco-squid@{version}
+sqd tags add prod -o pendulum --slot v{version} --name pendulum-squid
+sqd tags add prod -o pendulum --slot v{version} --name amplitude-squid
+sqd tags add prod -o pendulum --slot v{version} --name foucoco-squid
 ```
 
 #### Versioning

--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 26
+version: 27
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 27
+version: 29
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/squid-foucoco.yaml
+++ b/squid-foucoco.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: foucoco-squid
-version: 26
+version: 28
 description: 'Foucoco Squid'
 build:
 deploy:

--- a/squid-foucoco.yaml
+++ b/squid-foucoco.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: foucoco-squid
-version: 28
+version: 29
 description: 'Foucoco Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 26
+version: 29
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 29
+version: 30
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/src/mappings/nabla/handleEvent.ts
+++ b/src/mappings/nabla/handleEvent.ts
@@ -39,6 +39,9 @@ export async function handleContractInstantiated(ctx: EventHandlerContext) {
         case swapPoolAbi.metadata.source.hash:
             await createSwapPool(ctx, contractHexAddress)
             break
+        case '0x90c0d03030a2ba21a18c33af3c9931fc0f0a988b31f081bcc2c86c7107c48ccd': // Hash of the new SwapPool for BRLA
+            await createSwapPool(ctx, contractHexAddress)
+            break
     }
 }
 


### PR DESCRIPTION
- Also adds manual handling for the BRLA pool, which was compiled form a different Nabla version and therefore has a different code hash.
- README changes.