### PR TITLE
Fix indexer getting stuck randomly due to missing parent `call` entry.

### DIFF
--- a/db/migrations/1764083587976-Data.js
+++ b/db/migrations/1764083587976-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1728408180596 {
-    name = 'Data1728408180596'
+module.exports = class Data1764083587976 {
+    name = 'Data1764083587976'
 
     async up(db) {
         await db.query(
@@ -399,16 +399,13 @@ module.exports = class Data1728408180596 {
             `CREATE INDEX "IDX_0a00d817e614a91cda40d734cf" ON "event" ("id", "pallet", "name") `
         )
         await db.query(
-            `CREATE TABLE "call" ("id" character varying NOT NULL, "address" integer array NOT NULL, "success" boolean NOT NULL, "error" jsonb, "pallet" text NOT NULL, "name" text NOT NULL, "args" jsonb, "args_str" text array, "block_id" character varying, "extrinsic_id" character varying, "parent_id" character varying, CONSTRAINT "PK_2098af0169792a34f9cfdd39c47" PRIMARY KEY ("id"))`
+            `CREATE TABLE "call" ("id" character varying NOT NULL, "address" integer array NOT NULL, "success" boolean NOT NULL, "error" jsonb, "pallet" text NOT NULL, "name" text NOT NULL, "args" jsonb, "args_str" text array, "block_id" character varying, "extrinsic_id" character varying, CONSTRAINT "PK_2098af0169792a34f9cfdd39c47" PRIMARY KEY ("id"))`
         )
         await db.query(
             `CREATE INDEX "IDX_bd3f11fd4110d60ac8b96cd62f" ON "call" ("block_id") `
         )
         await db.query(
             `CREATE INDEX "IDX_dde30e4f2c6a80f9236bfdf259" ON "call" ("extrinsic_id") `
-        )
-        await db.query(
-            `CREATE INDEX "IDX_11c1e76d5be8f04c472c4a05b9" ON "call" ("parent_id") `
         )
         await db.query(
             `CREATE INDEX "IDX_d3a8c3d00494950ad6dc93297d" ON "call" ("success") `
@@ -648,9 +645,6 @@ module.exports = class Data1728408180596 {
             `ALTER TABLE "call" ADD CONSTRAINT "FK_dde30e4f2c6a80f9236bfdf2590" FOREIGN KEY ("extrinsic_id") REFERENCES "extrinsic"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
         )
         await db.query(
-            `ALTER TABLE "call" ADD CONSTRAINT "FK_11c1e76d5be8f04c472c4a05b95" FOREIGN KEY ("parent_id") REFERENCES "call"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
-        )
-        await db.query(
             `ALTER TABLE "extrinsic" ADD CONSTRAINT "FK_a3b99daba1259dab0dd040d4f74" FOREIGN KEY ("block_id") REFERENCES "block"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
         )
         await db.query(
@@ -794,7 +788,6 @@ module.exports = class Data1728408180596 {
         await db.query(`DROP TABLE "call"`)
         await db.query(`DROP INDEX "public"."IDX_bd3f11fd4110d60ac8b96cd62f"`)
         await db.query(`DROP INDEX "public"."IDX_dde30e4f2c6a80f9236bfdf259"`)
-        await db.query(`DROP INDEX "public"."IDX_11c1e76d5be8f04c472c4a05b9"`)
         await db.query(`DROP INDEX "public"."IDX_d3a8c3d00494950ad6dc93297d"`)
         await db.query(`DROP INDEX "public"."IDX_776bccbd3d7b3001c8708cf4e0"`)
         await db.query(`DROP INDEX "public"."IDX_8b212022b7428232091e2f8aa5"`)
@@ -993,9 +986,6 @@ module.exports = class Data1728408180596 {
         )
         await db.query(
             `ALTER TABLE "call" DROP CONSTRAINT "FK_dde30e4f2c6a80f9236bfdf2590"`
-        )
-        await db.query(
-            `ALTER TABLE "call" DROP CONSTRAINT "FK_11c1e76d5be8f04c472c4a05b95"`
         )
         await db.query(
             `ALTER TABLE "extrinsic" DROP CONSTRAINT "FK_a3b99daba1259dab0dd040d4f74"`

--- a/schema.graphql
+++ b/schema.graphql
@@ -962,7 +962,6 @@ type Call @entity @index(fields: ["id", "pallet", "name"]) {
 
     block: Block!
     extrinsic: Extrinsic
-    parent: Call
 
     address: [Int!]!
     success: Boolean! @index
@@ -974,7 +973,6 @@ type Call @entity @index(fields: ["id", "pallet", "name"]) {
     args: JSON
     argsStr: [String]
 
-    subcalls: [Call]! @derivedFrom(field: "parent")
     events: [Event]! @derivedFrom(field: "call")
 }
 

--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 29
+version: 30
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/squid-foucoco.yaml
+++ b/squid-foucoco.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: foucoco-squid
-version: 29
+version: 30
 description: 'Foucoco Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 35
+version: 40
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 31
+version: 34
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 34
+version: 35
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 40
+version: 30
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/src/mappings/block-details.ts
+++ b/src/mappings/block-details.ts
@@ -53,11 +53,8 @@ export async function pruneOldestBlock(ctx: Ctx, blockToPruneHeight: number) {
         for (const call of callsToUpdate) {
             call.extrinsic = null
         }
-        try {
-            await ctx.store.save(callsToUpdate)
-        } catch (e) {
-            console.log('error updating calls while pruning: ', e)
-        }
+
+        await ctx.store.save(callsToUpdate)
 
         // Delete associated extrinsics
         const extrinsicsToPrune = await ctx.store.findBy(model.Extrinsic, {
@@ -70,13 +67,9 @@ export async function pruneOldestBlock(ctx: Ctx, blockToPruneHeight: number) {
             block: { id: blockToPrune.id },
         })
 
-        try {
-            await ctx.store.remove(callsToPrune)
-            // Finally, delete the block itself
-            await ctx.store.remove(model.Block, blockToPrune.id)
-        } catch (e) {
-            console.log('error removing calls while pruning: ', e)
-        }
+        await ctx.store.remove(callsToPrune)
+        // Finally, delete the block itself
+        await ctx.store.remove(model.Block, blockToPrune.id)
     }
 }
 

--- a/src/mappings/block-details.ts
+++ b/src/mappings/block-details.ts
@@ -53,7 +53,11 @@ export async function pruneOldestBlock(ctx: Ctx, blockToPruneHeight: number) {
         for (const call of callsToUpdate) {
             call.extrinsic = null
         }
-        await ctx.store.save(callsToUpdate)
+        try {
+            await ctx.store.save(callsToUpdate)
+        } catch (e) {
+            console.log('error updating calls while pruning: ', e)
+        }
 
         // Delete associated extrinsics
         const extrinsicsToPrune = await ctx.store.findBy(model.Extrinsic, {
@@ -65,86 +69,90 @@ export async function pruneOldestBlock(ctx: Ctx, blockToPruneHeight: number) {
         const callsToPrune = await ctx.store.findBy(model.Call, {
             block: { id: blockToPrune.id },
         })
-        await ctx.store.remove(callsToPrune)
 
-        // Finally, delete the block itself
-        await ctx.store.remove(model.Block, blockToPrune.id)
-    }
-}
-
-export async function saveExtrinsic(ctx: Ctx, extrinsic: Extrinsic_) {
-    const block = await ctx.store.get(model.Block, extrinsic.block.id)
-
-    if (block == null) {
-        throw new Error('Failed to save extrinsic')
+        try {
+            await ctx.store.remove(callsToPrune)
+            // Finally, delete the block itself
+            await ctx.store.remove(model.Block, blockToPrune.id)
+        } catch (e) {
+            console.log('error removing calls while pruning: ', e)
+        }
     }
 
-    const entity = new model.Extrinsic({
-        id: extrinsic.id,
-        block,
-        error: extrinsic.error,
-        fee: extrinsic.fee,
-        hash: decodeHex(extrinsic.hash),
-        index: extrinsic.index,
-        signature: new model.ExtrinsicSignature(extrinsic.signature),
-        success: extrinsic.success,
-        tip: extrinsic.tip,
-        version: extrinsic.version,
-    })
-    await ctx.store.insert(entity)
+    export async function saveExtrinsic(ctx: Ctx, extrinsic: Extrinsic_) {
+        const block = await ctx.store.get(model.Block, extrinsic.block.id)
 
-    block.extrinsicsCount += 1
-    await ctx.store.upsert(block)
-}
+        if (block == null) {
+            throw new Error('Failed to save extrinsic')
+        }
 
-export async function saveCall(ctx: Ctx, call: Call_) {
-    const block = await ctx.store.get(model.Block, call.block.id)
-    const extrinsic = await ctx.store.get(
-        model.Extrinsic,
-        call.getExtrinsic().id
-    )
-    const parent = call.parentCall
-        ? await ctx.store.get(model.Call, call.parentCall.id)
-        : undefined
-    if (
-        block == null ||
-        extrinsic == null ||
-        (call.parentCall && parent == null)
-    ) {
-        throw new Error('Failed to save call')
-    }
-
-    const [pallet, name] = call.name.split('.')
-
-    const entity = new model.Call({
-        id: call.id,
-        block,
-        address: call.address,
-        args: call.args,
-        error: call.error,
-        extrinsic,
-        name,
-        pallet,
-        parent,
-        success: call.success,
-    })
-
-    try {
+        const entity = new model.Extrinsic({
+            id: extrinsic.id,
+            block,
+            error: extrinsic.error,
+            fee: extrinsic.fee,
+            hash: decodeHex(extrinsic.hash),
+            index: extrinsic.index,
+            signature: new model.ExtrinsicSignature(extrinsic.signature),
+            success: extrinsic.success,
+            tip: extrinsic.tip,
+            version: extrinsic.version,
+        })
         await ctx.store.insert(entity)
 
-        block.callsCount += 1
+        block.extrinsicsCount += 1
         await ctx.store.upsert(block)
+    }
 
-        if (call.address.length == 0) {
-            extrinsic.call = entity
-            await ctx.store.upsert(extrinsic)
-        }
-    } catch (e) {
-        console.log(
-            `Error saving call ${call.name} with id ${call.id}, parentCallId: ${call.parentCall?.id}, found parent in DB: ${parent}`
+    export async function saveCall(ctx: Ctx, call: Call_) {
+        const block = await ctx.store.get(model.Block, call.block.id)
+        const extrinsic = await ctx.store.get(
+            model.Extrinsic,
+            call.getExtrinsic().id
         )
-        console.log(`call data: `, call.args, call.address)
-        console.log('Error inserting call: ', e)
+        const parent = call.parentCall
+            ? await ctx.store.get(model.Call, call.parentCall.id)
+            : undefined
+        if (
+            block == null ||
+            extrinsic == null ||
+            (call.parentCall && parent == null)
+        ) {
+            throw new Error('Failed to save call')
+        }
+
+        const [pallet, name] = call.name.split('.')
+
+        const entity = new model.Call({
+            id: call.id,
+            block,
+            address: call.address,
+            args: call.args,
+            error: call.error,
+            extrinsic,
+            name,
+            pallet,
+            parent,
+            success: call.success,
+        })
+
+        try {
+            await ctx.store.insert(entity)
+
+            block.callsCount += 1
+            await ctx.store.upsert(block)
+
+            if (call.address.length == 0) {
+                extrinsic.call = entity
+                await ctx.store.upsert(extrinsic)
+            }
+        } catch (e) {
+            console.log(
+                `Error saving call ${call.name} with id ${call.id}, parentCallId: ${call.parentCall?.id}, found parent in DB: ${parent}`
+            )
+            console.log(`call data: `, call.args, call.address)
+            console.log('Error inserting call: ', e)
+        }
     }
 }
 

--- a/src/mappings/block-details.ts
+++ b/src/mappings/block-details.ts
@@ -106,7 +106,6 @@ export async function saveCall(ctx: Ctx, call: Call_) {
     const parent = call.parentCall
         ? await ctx.store.get(model.Call, call.parentCall.id)
         : undefined
-
     if (
         block == null ||
         extrinsic == null ||
@@ -129,14 +128,23 @@ export async function saveCall(ctx: Ctx, call: Call_) {
         parent,
         success: call.success,
     })
-    await ctx.store.insert(entity)
 
-    block.callsCount += 1
-    await ctx.store.upsert(block)
+    try {
+        await ctx.store.insert(entity)
 
-    if (call.address.length == 0) {
-        extrinsic.call = entity
-        await ctx.store.upsert(extrinsic)
+        block.callsCount += 1
+        await ctx.store.upsert(block)
+
+        if (call.address.length == 0) {
+            extrinsic.call = entity
+            await ctx.store.upsert(extrinsic)
+        }
+    } catch (e) {
+        console.log(
+            `Error saving call ${call.name} with id ${call.id}, parentCallId: ${call.parentCall?.id}, found parent in DB: ${parent}`
+        )
+        console.log(`call data: `, call.args, call.address)
+        console.log('Error inserting call: ', e)
     }
 }
 

--- a/src/mappings/block-details.ts
+++ b/src/mappings/block-details.ts
@@ -78,81 +78,66 @@ export async function pruneOldestBlock(ctx: Ctx, blockToPruneHeight: number) {
             console.log('error removing calls while pruning: ', e)
         }
     }
+}
 
-    export async function saveExtrinsic(ctx: Ctx, extrinsic: Extrinsic_) {
-        const block = await ctx.store.get(model.Block, extrinsic.block.id)
+export async function saveExtrinsic(ctx: Ctx, extrinsic: Extrinsic_) {
+    const block = await ctx.store.get(model.Block, extrinsic.block.id)
 
-        if (block == null) {
-            throw new Error('Failed to save extrinsic')
-        }
-
-        const entity = new model.Extrinsic({
-            id: extrinsic.id,
-            block,
-            error: extrinsic.error,
-            fee: extrinsic.fee,
-            hash: decodeHex(extrinsic.hash),
-            index: extrinsic.index,
-            signature: new model.ExtrinsicSignature(extrinsic.signature),
-            success: extrinsic.success,
-            tip: extrinsic.tip,
-            version: extrinsic.version,
-        })
-        await ctx.store.insert(entity)
-
-        block.extrinsicsCount += 1
-        await ctx.store.upsert(block)
+    if (block == null) {
+        throw new Error('Failed to save extrinsic')
     }
 
-    export async function saveCall(ctx: Ctx, call: Call_) {
-        const block = await ctx.store.get(model.Block, call.block.id)
-        const extrinsic = await ctx.store.get(
-            model.Extrinsic,
-            call.getExtrinsic().id
-        )
-        const parent = call.parentCall
-            ? await ctx.store.get(model.Call, call.parentCall.id)
-            : undefined
-        if (
-            block == null ||
-            extrinsic == null ||
-            (call.parentCall && parent == null)
-        ) {
-            throw new Error('Failed to save call')
-        }
+    const entity = new model.Extrinsic({
+        id: extrinsic.id,
+        block,
+        error: extrinsic.error,
+        fee: extrinsic.fee,
+        hash: decodeHex(extrinsic.hash),
+        index: extrinsic.index,
+        signature: new model.ExtrinsicSignature(extrinsic.signature),
+        success: extrinsic.success,
+        tip: extrinsic.tip,
+        version: extrinsic.version,
+    })
+    await ctx.store.insert(entity)
 
-        const [pallet, name] = call.name.split('.')
+    block.extrinsicsCount += 1
+    await ctx.store.upsert(block)
+}
 
-        const entity = new model.Call({
-            id: call.id,
-            block,
-            address: call.address,
-            args: call.args,
-            error: call.error,
-            extrinsic,
-            name,
-            pallet,
-            parent,
-            success: call.success,
-        })
+export async function saveCall(ctx: Ctx, call: Call_) {
+    const block = await ctx.store.get(model.Block, call.block.id)
+    const extrinsic = await ctx.store.get(
+        model.Extrinsic,
+        call.getExtrinsic().id
+    )
 
-        try {
-            await ctx.store.insert(entity)
+    if (block == null || extrinsic == null) {
+        throw new Error('Failed to save call')
+    }
 
-            block.callsCount += 1
-            await ctx.store.upsert(block)
+    const [pallet, name] = call.name.split('.')
 
-            if (call.address.length == 0) {
-                extrinsic.call = entity
-                await ctx.store.upsert(extrinsic)
-            }
-        } catch (e) {
-            console.log(
-                `Error saving call ${call.name} with id ${call.id}, parentCallId: ${call.parentCall?.id}, found parent in DB: ${parent}`
-            )
-            console.log(`call data: `, call.args, call.address)
-            console.log('Error inserting call: ', e)
-        }
+    const entity = new model.Call({
+        id: call.id,
+        block,
+        address: call.address,
+        args: call.args,
+        error: call.error,
+        extrinsic,
+        name,
+        pallet,
+        success: call.success,
+    })
+
+    await ctx.store.insert(entity)
+
+    block.callsCount += 1
+    await ctx.store.upsert(block)
+
+    if (call.address.length == 0) {
+        extrinsic.call = entity
+        await ctx.store.upsert(extrinsic)
     }
 }
 

--- a/src/model/generated/call.model.ts
+++ b/src/model/generated/call.model.ts
@@ -32,10 +32,6 @@ export class Call {
     @ManyToOne_(() => Extrinsic, { nullable: true })
     extrinsic!: Extrinsic | undefined | null
 
-    @Index_()
-    @ManyToOne_(() => Call, { nullable: true })
-    parent!: Call | undefined | null
-
     @IntColumn_({ array: true, nullable: false })
     address!: number[]
 
@@ -59,9 +55,6 @@ export class Call {
 
     @StringColumn_({ array: true, nullable: true })
     argsStr!: (string | undefined | null)[] | undefined | null
-
-    @OneToMany_(() => Call, (e) => e.parent)
-    subcalls!: Call[]
 
     @OneToMany_(() => Event, (e) => e.call)
     events!: Event[]

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -443,6 +443,7 @@ processor.run(new TypeormDatabase(), async (ctx) => {
         // because for the system.remark call we need to have
         // processed the token transfers first
         for (const call of calls) {
+            console.log(`Processing call ${call} at block ${block.height}`)
             try {
                 switch (call.name) {
                     case 'Utility.batch':

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -443,7 +443,6 @@ processor.run(new TypeormDatabase(), async (ctx) => {
         // because for the system.remark call we need to have
         // processed the token transfers first
         for (const call of calls) {
-            console.log(`Processing call ${call} at block ${block.height}`)
             try {
                 switch (call.name) {
                     case 'Utility.batch':


### PR DESCRIPTION

Removes the `parent` field for the `Call` model. This prevents the error where a call would point to a missing parent entry, breaking the synchronisation. 

Since we do not use the `parent` field for any analysis, this doesn't affect the operation of the indexer.