### PR TITLE
Add other pendulum usdc tokens to zenlink whitelist

### DIFF
--- a/squid-amplitude.yaml
+++ b/squid-amplitude.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: amplitude-squid
-version: 30
+version: 31
 description: 'Amplitude Kusama Squid'
 build:
 deploy:

--- a/squid-foucoco.yaml
+++ b/squid-foucoco.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: foucoco-squid
-version: 30
+version: 31
 description: 'Foucoco Squid'
 build:
 deploy:

--- a/squid-pendulum.yaml
+++ b/squid-pendulum.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: pendulum-squid
-version: 30
+version: 31
 description: 'Pendulum Squid'
 build:
 deploy:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,6 +72,18 @@ export const TOKEN_METADATA_MAP: { [address: string]: TokenBase } = {
         blockchain: 'Polkadot',
         decimals: 10,
     },
+    '2094-2-258': {
+        name: 'Assethub USDC',
+        symbol: 'FIAT',
+        blockchain: 'USD-USD',
+        decimals: 6,
+    },
+    '2094-2-268': {
+        name: 'Axelar USDC',
+        symbol: 'FIAT',
+        blockchain: 'USD-USD',
+        decimals: 6,
+    },
     '2094-2-262': {
         name: 'Moonbeam',
         symbol: 'GLMR',

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -48,7 +48,9 @@ export const WHITELIST: string[] = [
     '2124-2-515', // brl
     '2094-0-0', // wnative pendulum
     '2094-2-256', // dot
+    '2094-2-258', // Assethub USDC
     '2094-2-262', // glmr
+    '2094-2-268', // Axelar USDC
     '2094-2-512', // xlm
     '2094-2-513', // usdc
 ]


### PR DESCRIPTION
Manifest version updates:

* Increased the `version` field from 30 to 31 in the `squid-amplitude.yaml`, `squid-foucoco.yaml`, and `squid-pendulum.yaml` manifest files to reflect the latest deployment version. [[1]](diffhunk://#diff-870b1e01b0a9eaaf83c438ae95497b4ea2372364f486e2ae1c9176a9a88d3f8aL3-R3) [[2]](diffhunk://#diff-dd67aa460e376c8feae8ea0f5626d3e01765ada552fecabe681fac741515be9cL3-R3) [[3]](diffhunk://#diff-56b2ebd6a7d875ffb6b350b7793bc654190963679023cadda1dbcba6b2190ed1L3-R3)

Asset whitelist enhancements:

* Added `2094-2-258` (Assethub USDC) and `2094-2-268` (Axelar USDC) to the `WHITELIST` array in `src/utils/pricing.ts`, allowing these assets to be included in pricing calculations.